### PR TITLE
remove output port bitblast index

### DIFF
--- a/passes/cmds/splitnetlist.cc
+++ b/passes/cmds/splitnetlist.cc
@@ -102,6 +102,7 @@ void lhs2rhs(RTLIL::Design *design, dict<RTLIL::SigSpec, RTLIL::SigSpec> &lhsSig
 			continue;
 		}
 		if (!lhs.is_chunk()) {
+			// If lhs is not a chunk (leaf) ie: assign {a,b} = ..., then bitblast both lhs and rhs
 			std::vector<SigSpec> lhsBits;
 			for (int i = 0; i < lhs.size(); i++) {
 				SigSpec bit_sig = lhs.extract(i, 1);

--- a/passes/cmds/splitnetlist.cc
+++ b/passes/cmds/splitnetlist.cc
@@ -76,6 +76,16 @@ void sigCellDrivers(RTLIL::Design *design, dict<RTLIL::SigSpec, std::set<Cell *>
 						sig2CellsInFanin[actual] = newSet;
 					}
 					newSet->insert(cell);
+					for (int i = 0; i < actual.size(); i++) {
+						SigSpec bit_sig = actual.extract(i, 1);
+						if (sig2CellsInFanin.count(bit_sig)) {
+							newSet = sig2CellsInFanin[bit_sig];
+						} else {
+							newSet = new std::set<Cell *>;
+							sig2CellsInFanin[bit_sig] = newSet;
+						}
+						newSet->insert(cell);
+					}
 				}
 			}
 		}
@@ -92,38 +102,19 @@ void lhs2rhs(RTLIL::Design *design, dict<RTLIL::SigSpec, RTLIL::SigSpec> &lhsSig
 			continue;
 		}
 		if (!lhs.is_chunk()) {
-			if (lhs.chunks().size() != rhs.chunks().size()) {
-				auto rit = rhs.chunks().rbegin();
-				long unsigned rhsSize = 0;
-				while (rit != rhs.chunks().rend()) {
-					RTLIL::SigSpec sub_rhs = *rit;
-					if (sub_rhs.is_fully_const()) {
-						rhsSize += (sub_rhs.as_chunk()).width;
-					} else {
-						rhsSize++;
-					}
-					rit++;
-				}
-				if (lhs.chunks().size() != rhsSize) {
-					continue;
-				}
+			std::vector<SigSpec> lhsBits;
+			for (int i = 0; i < lhs.size(); i++) {
+				SigSpec bit_sig = lhs.extract(i, 1);
+				lhsBits.push_back(bit_sig);
 			}
-			auto lit = lhs.chunks().rbegin();
-			auto rit = rhs.chunks().rbegin();
-			while (rit != rhs.chunks().rend()) {
-				RTLIL::SigSpec sub_lhs = *lit;
-				RTLIL::SigSpec sub_rhs = *rit;
-				if (sub_rhs.is_fully_const()) {
-					int constSize = (sub_rhs.as_chunk()).width;
-					while (constSize--) {
-						lit++;
-					}
-					rit++;
-					continue;
-				}
-				lhsSig2rhsSig[sub_lhs] = sub_rhs;
-				lit++;
-				rit++;
+			std::vector<SigSpec> rhsBits;
+			for (int i = 0; i < rhs.size(); i++) {
+				SigSpec bit_sig = rhs.extract(i, 1);
+				rhsBits.push_back(bit_sig);
+			}
+			for (uint32_t i = 0; i < lhsBits.size(); i++) {
+				if (i < rhsBits.size())
+				  lhsSig2rhsSig[lhsBits[i]] = rhsBits[i];
 			}
 		} else {
 			lhsSig2rhsSig[lhs] = rhs;

--- a/passes/cmds/splitnetlist.cc
+++ b/passes/cmds/splitnetlist.cc
@@ -172,29 +172,25 @@ struct SplitNetlist : public ScriptPass {
 			if (!wire->port_output)
 				continue;
 			std::string output_port_name = wire->name.c_str();
+			if (output_port_name.empty())
+				continue;
 			// We want to truncate the final _<index>_ part of the string
 			// Example: "add_Y_0_"
 			// Result:  "add_Y"
-			bool bitblastedIndex = false;
 			std::string::iterator end = output_port_name.end()-1;
-			for (; end !=  output_port_name.begin(); end--) {
-				char c = (*end);
-				if ((end == output_port_name.end()-1) && (c == '_')) {
-					// bit blasted index
-					bitblastedIndex = true;
-					continue;
-				}
-				if (bitblastedIndex) {
-					if (c != '_') {
+			if ((*end) == '_') {
+				// Last character is an _, it is a bit blasted index
+				end--;
+				for (; end !=  output_port_name.begin(); end--) {
+					if ((*end) != '_') {
+						// Truncate until the next _
 						continue;
 					} else {
-						end--;
+						// Truncate the _
 						break;
 					}
 				}
 			}
-			if (!bitblastedIndex)
-				end = output_port_name.end()-1;
 			std::string no_bitblast_prefix;
 			std::copy(output_port_name.begin(), end, std::back_inserter(no_bitblast_prefix));
 			// We then truncate the port name, Result: "add"


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

// We want to truncate the final _<index>_ part of the string
// Example: "add_Y_0_"
// Result:  "add_Y"
// We then truncate the port name, Result: "add"

_Explain how this is achieved._

_If applicable, please suggest to reviewers how they can test the change._
