### PR TITLE
Memory size check

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1676,7 +1676,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 				log_error("Verific RamNet %s is connected to unsupported instance type %s (%s).\n",
 						net->Name(), pr->GetInst()->View()->Owner()->Name(), pr->GetInst()->Name());
 			}
-			if (bits_in_word * number_of_bits > pow(2, 23))
+			if ((bits_in_word * number_of_bits) > (1 << 23))
 				log_error("Memory %s size is larger than 2**23 bits\n", net->Name());
 			memory->width = bits_in_word;
 			memory->size = number_of_bits / bits_in_word;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Similar message to the Verific error message issued when memory size exceed 2^23 bits, but this message is issued in every case of "verific -cfg veri_extract_multiport_rams 0/1"

_Explain how this is achieved._

_If applicable, please suggest to reviewers how they can test the change._
