### PR TITLE
opt_expand test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -946,6 +946,7 @@ SH_TEST_DIRS += tests/blif
 SH_TEST_DIRS += tests/memfile
 SH_TEST_DIRS += tests/fmt
 # SH_TEST_DIRS += tests/cxxrtl
+SH_TEST_DIRS += tests/silimate
 ifeq ($(ENABLE_FUNCTIONAL_TESTS),1)
 SH_TEST_DIRS += tests/functional
 endif

--- a/tests/silimate/opt_expand.ys
+++ b/tests/silimate/opt_expand.ys
@@ -15,19 +15,10 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 1 t:$and
-select -assert-count 1 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
-
 design -reset
 log -pop
 
@@ -47,15 +38,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 1 t:$and
-select -assert-count 1 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -79,15 +62,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 1 t:$and
-select -assert-count 1 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -114,15 +89,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 1 t:$and
-select -assert-count 1 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 1 t:$and
 select -assert-count 1 t:$or
@@ -147,15 +114,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 2 t:$and
-select -assert-count 1 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 3 t:$and
 select -assert-count 1 t:$or
@@ -180,15 +139,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 1 t:$and
-select -assert-count 2 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 3 t:$and
 select -assert-count 2 t:$or
@@ -212,15 +163,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 1 t:$and
-select -assert-count 1 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -246,15 +189,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 2 t:$and
-select -assert-count 2 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 4 t:$and
 select -assert-count 2 t:$or
@@ -281,15 +216,7 @@ module top (
 endmodule
 EOF
 check -assert
-
-# Ensure original design only has correct number of gates
-select -assert-count 2 t:$and
-select -assert-count 3 t:$or
-
-# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
-
-# Check final design has correct number of gates
 design -load postopt
 select -assert-count 4 t:$and
 select -assert-count 3 t:$or

--- a/tests/silimate/opt_expand.ys
+++ b/tests/silimate/opt_expand.ys
@@ -15,10 +15,19 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
+
 design -reset
 log -pop
 
@@ -38,7 +47,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -62,7 +79,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -89,7 +114,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 1 t:$and
 select -assert-count 1 t:$or
@@ -114,7 +147,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 2 t:$and
+select -assert-count 1 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 3 t:$and
 select -assert-count 1 t:$or
@@ -139,7 +180,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 1 t:$and
+select -assert-count 2 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 3 t:$and
 select -assert-count 2 t:$or
@@ -163,7 +212,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -189,7 +246,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 2 t:$and
+select -assert-count 2 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 4 t:$and
 select -assert-count 2 t:$or
@@ -216,7 +281,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Ensure original design only has correct number of gates
+select -assert-count 2 t:$and
+select -assert-count 3 t:$or
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 4 t:$and
 select -assert-count 3 t:$or

--- a/tests/silimate/opt_expand.ys
+++ b/tests/silimate/opt_expand.ys
@@ -1,0 +1,225 @@
+log -header "Simple positive case"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  output wire x
+);
+  wire m;
+
+  assign m = a | b;
+  assign x = m & c;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 2 t:$and
+select -assert-count 1 t:$or
+design -reset
+log -pop
+
+
+
+log -header "No intermediate wire: (a | b) & c"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  output wire x
+);
+  assign x = (a | b) & c;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 2 t:$and
+select -assert-count 1 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "No intermediate wire flipped: c & (a | b)"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  output wire x
+);
+  assign x = c & (a | b);
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 2 t:$and
+select -assert-count 1 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "Fanout from intermediate wire"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  output wire m,
+  output wire x
+);
+  assign m = a | b;
+  assign x = c & m;
+
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "Nested AND gate: ((a & b) | c) & d"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire x
+);
+  assign x = ((a & b) | c) & d;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 3 t:$and
+select -assert-count 1 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "Nested OR gate: ((a | b) | c) & d"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire x
+);
+  assign x = ((a | b) | c) & d;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 3 t:$and
+select -assert-count 2 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "With inverter: (~a | b) & c"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  output wire x
+);
+  assign x = (~a | b) & c;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 2 t:$and
+select -assert-count 1 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "Deeper nesting: ((a | b) & (c | d)) & e"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  input wire e,
+  output wire x
+);
+  assign x = ((a | b) & (c | d)) & e;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 4 t:$and
+select -assert-count 2 t:$or
+
+design -reset
+log -pop
+
+
+
+log -header "More inputs and nesting: ((a | b | c) & (d | e)) & f"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  input wire e,
+  input wire f,
+  output wire x
+);
+  assign x = ((a | b | c) & (d | e)) & f;
+endmodule
+EOF
+check -assert
+equiv_opt -assert opt_expand
+design -load postopt
+select -assert-count 4 t:$and
+select -assert-count 3 t:$or
+
+design -reset
+log -pop

--- a/tests/silimate/opt_expand.ys
+++ b/tests/silimate/opt_expand.ys
@@ -15,10 +15,15 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
+
 design -reset
 log -pop
 
@@ -38,7 +43,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -62,7 +71,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -89,7 +102,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 1 t:$and
 select -assert-count 1 t:$or
@@ -114,7 +131,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 3 t:$and
 select -assert-count 1 t:$or
@@ -139,7 +160,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 3 t:$and
 select -assert-count 2 t:$or
@@ -163,7 +188,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 2 t:$and
 select -assert-count 1 t:$or
@@ -189,7 +218,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 4 t:$and
 select -assert-count 2 t:$or
@@ -216,7 +249,11 @@ module top (
 endmodule
 EOF
 check -assert
+
+# Check equivalence after opt_expand
 equiv_opt -assert opt_expand
+
+# Check final design has correct number of gates
 design -load postopt
 select -assert-count 4 t:$and
 select -assert-count 3 t:$or

--- a/tests/silimate/run-test.sh
+++ b/tests/silimate/run-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+for x in *.ys; do
+  echo "Running $x.."
+  ../../yosys -ql ${x%.ys}.log $x
+done


### PR DESCRIPTION
Added test cases for the opt_expand pass. The test case cover the following cases:

1. Simple test cases with and without an intermediate wire
2. Case where the intermediate wire is actually used in a fanout (in this case, it should not optimize)
3. Cases with nested gates
4. Cases with extra gates (specifically inverter)
5. Deeply nested configurations