### PR TITLE
Added new muxorder tests

### DIFF
--- a/tests/peepopt/muxorder.ys
+++ b/tests/peepopt/muxorder.ys
@@ -1,5 +1,3 @@
-
-
 log -header "Test basic s?(a+b):a pattern gets transformed (a,b module inputs)"
 log -push
 design -reset
@@ -368,6 +366,151 @@ module top(a, b, s, y);
 	input wire s;
 	wire signed [4:0] ab = a + b;
 	assign y = s ? ab : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
+
+log -pop
+log -header "Test transform when widths are uneven with no intermediate values"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire [3:0] a;
+	input wire [2:0] b;
+	output wire [4:0] y;
+	input wire s;
+	assign y = s ? a + b : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
+
+log -pop
+log -header "Test basic s ? (a * b) : a"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire [3:0] a;
+	input wire [3:0] b;
+	output wire [3:0] y;
+	input wire s;
+	assign y = s ? a * b : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$mul %co1 %a w:y %i # assert mult rewired
+
+log -pop
+log -header "Test basic s ? (a & b) : a"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire [3:0] a;
+	input wire [3:0] b;
+	output wire [3:0] y;
+	input wire s;
+	assign y = s ? a & b : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$and %co1 %a w:y %i # assert and rewired
+
+log -pop
+log -header "Test basic s ? (a | b) : a"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire a;
+	input wire b;
+	output wire y;
+	input wire s;
+	assign y = s ? a | b : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$or %co1 %a w:y %i # assert or rewired
+
+log -pop
+log -header "Test basic s ? (a ^ b) : a"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire [3:0] a;
+	input wire [3:0] b;
+	output wire [3:0] y;
+	input wire s;
+	assign y = s ? a ^ b : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$xor %co1 %a w:y %i # assert xor rewired
+
+log -pop
+log -header "Test basic s ? (a ~^ b) : a"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire [3:0] a;
+	input wire [3:0] b;
+	output wire [3:0] y;
+	input wire s;
+	assign y = s ? a ~^ b : a;
+endmodule
+EOF
+check -assert
+wreduce
+opt_clean
+equiv_opt -assert peepopt -muxorder
+design -load postopt
+select -assert-any t:$xnor %co1 %a w:y %i # assert xnor rewired
+
+log -pop
+log -header "Nested conditionals"
+log -push
+design -reset
+read_verilog <<EOF
+module top(a, b, c, s0, s1, y);
+	input wire [3:0] a;
+	input wire [3:0] b;
+	input wire [3:0] c;
+	output wire [3:0] y;
+	input wire s0, s1;
+
+	wire [3:0] inter;
+	
+	assign inter = s0 ? a + b : a;
+	assign y = s1 ? inter + c : inter;
 endmodule
 EOF
 check -assert


### PR DESCRIPTION
New tests for muxorder pass
- Tests all operators
- Tests nested muxes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added comprehensive tests for mux operations in `muxorder.ys`, covering various operators, nested conditions, and edge cases.
> 
>   - **Tests Added**:
>     - Added tests for basic mux operations with different operators: `+`, `*`, `&`, `|`, `^`, `~^`.
>     - Added tests for nested mux operations.
>     - Added tests for scenarios with uneven operand widths.
>   - **Behavior**:
>     - Tests ensure correct transformation and rewiring of operations in mux patterns.
>     - Includes assertions to verify correct rewiring of adders, multipliers, and other operators.
>     - Tests cover cases where transformations should not occur due to specific conditions (e.g., more fanouts, width mismatches).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fyosys&utm_source=github&utm_medium=referral)<sup> for 82fa68aa2d92e0f68415163221543fffa6b7bc1b. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->