### PR TITLE
Added opt_balance_tree tests

### DIFF
--- a/tests/silimate/opt_balance_tree.ys
+++ b/tests/silimate/opt_balance_tree.ys
@@ -19,8 +19,7 @@ EOF
 check -assert
 
 # Check equivalence after opt_expand
-# equiv_opt -assert opt_balance_tree
-opt_balance_tree
+equiv_opt -assert opt_balance_tree
 
 # TODO check design to make sure that it is not turned into a tree
 # design -load postopt
@@ -51,8 +50,7 @@ EOF
 check -assert
 
 # Check equivalence after opt_expand
-# equiv_opt -assert opt_balance_tree
-opt_balance_tree
+equiv_opt -assert opt_balance_tree
 
 # TODO check design to make sure that it is not turned into a tree
 # Note: this one already worked, just including here for completeness
@@ -80,8 +78,7 @@ EOF
 check -assert
 
 # Check equivalence after opt_expand
-# equiv_opt -assert opt_balance_tree
-opt_balance_tree
+equiv_opt -assert opt_balance_tree
 
 # TODO check design to make sure that it is not turned into a tree
 # Note: this one already worked, just including here for completeness
@@ -112,8 +109,7 @@ EOF
 check -assert
 
 # Check equivalence after opt_expand
-# equiv_opt -assert opt_balance_tree
-opt_balance_tree
+equiv_opt -assert opt_balance_tree
 
 # TODO check design to make sure that it is not turned into a tree
 # Note: this one already worked, just including here for completeness
@@ -142,8 +138,7 @@ EOF
 check -assert
 
 # Check equivalence after opt_expand
-# equiv_opt -assert opt_balance_tree
-opt_balance_tree
+equiv_opt -assert opt_balance_tree
 
 # TODO check design to make sure that it is not turned into a tree
 # Note: this one already worked, just including here for completeness

--- a/tests/silimate/opt_balance_tree.ys
+++ b/tests/silimate/opt_balance_tree.ys
@@ -1,0 +1,153 @@
+log -header "Should not be turned into a tree"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire x,
+  output wire y,
+  output wire z
+);
+  assign x = a & b;
+  assign y = x & c;
+  assign z = y & d;
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_expand
+# equiv_opt -assert opt_balance_tree
+opt_balance_tree
+
+# TODO check design to make sure that it is not turned into a tree
+# design -load postopt
+
+design -reset
+log -pop
+
+log -header "With a cell"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire x,
+  output wire y,
+  output wire z
+);
+  wire temp;
+  assign y = ~temp;
+  assign x = a & b;
+  assign temp = x & c;
+  assign z = temp & d;
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_expand
+# equiv_opt -assert opt_balance_tree
+opt_balance_tree
+
+# TODO check design to make sure that it is not turned into a tree
+# Note: this one already worked, just including here for completeness
+# design -load postopt
+
+design -reset
+log -pop
+
+log -header "Word out port"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire [2:0] x
+);
+  assign x[0] = a & b;
+  assign x[1] = x[0] & c;
+  assign x[2] = x[1] & d;
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_expand
+# equiv_opt -assert opt_balance_tree
+opt_balance_tree
+
+# TODO check design to make sure that it is not turned into a tree
+# Note: this one already worked, just including here for completeness
+# design -load postopt
+
+design -reset
+log -pop
+
+log -header "Fanout going to multiple outputs"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire [2:0] x,
+  output wire y
+);
+  assign x[0] = a & b;
+  assign x[1] = x[0] & c;
+  assign x[2] = x[1] & d;
+
+  assign y = x[1];
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_expand
+# equiv_opt -assert opt_balance_tree
+opt_balance_tree
+
+# TODO check design to make sure that it is not turned into a tree
+# Note: this one already worked, just including here for completeness
+# design -load postopt
+
+design -reset
+log -pop
+
+log -header "Fanout going to multiple of the same word"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire [3:0] x,
+);
+  assign x[0] = a & b;
+  assign x[1] = x[0] & c;
+  assign x[2] = x[1] & d;
+  assign x[3] = x[1];
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_expand
+# equiv_opt -assert opt_balance_tree
+opt_balance_tree
+
+# TODO check design to make sure that it is not turned into a tree
+# Note: this one already worked, just including here for completeness
+# design -load postopt
+
+design -reset
+log -pop

--- a/tests/silimate/opt_balance_tree.ys
+++ b/tests/silimate/opt_balance_tree.ys
@@ -20,22 +20,18 @@ equiv_opt -assert opt_balance_tree
 design -load postopt
 
 # Checks if inputs to and gates has been rewired
-select -set a_wires i:a %co
-select -set driven_by_a @a_wires %co
+select -set driven_by_a i:a %co %co
 select -set and_a_cell t:$and @driven_by_a %i
 
-select -set b_wires i:b %co
-select -set driven_by_b @b_wires %co
+select -set driven_by_b i:b %co %co
 select -set and_b_cell t:$and @driven_by_b %i
 
 select -assert-none @and_a_cell @and_b_cell %d
 
-select -set c_wires i:c %co
-select -set driven_by_c @c_wires %co
+select -set driven_by_c i:c %co %co
 select -set and_c_cell t:$and @driven_by_c %i
 
-select -set d_wires i:d %co
-select -set driven_by_d @d_wires %co
+select -set driven_by_d i:d %co %co
 select -set and_d_cell t:$and @driven_by_d %i
 
 select -assert-none @and_c_cell @and_d_cell %d
@@ -69,8 +65,7 @@ equiv_opt -assert opt_balance_tree
 design -load postopt
 
 # Checks if y is still wired up to the correct gate
-select -set y_wires o:y %ci
-select -set y_driver @y_wires %ci
+select -set y_driver o:y %ci %ci
 select -set and_y_cell t:$and @y_driver %i
 select @and_y_cell -assert-count 1
 select -set inputs @and_y_cell %ci
@@ -107,6 +102,13 @@ equiv_opt -assert opt_balance_tree
 design -load postopt
 select -assert-count 3 t:$and
 
+# Checks if temp is still wired up to the correct gate
+select -set temp_driver w:temp %ci %ci
+select -set and_cell t:$and @temp_driver %i
+select @and_cell -assert-count 1
+select -set inputs @and_cell %ci
+select -assert-count 1 @inputs i:c %i
+
 design -reset
 log -pop
 
@@ -124,6 +126,42 @@ module top (
   assign x[0] = a & b;
   assign x[1] = x[0] & c;
   assign x[2] = x[1] & d;
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_balance_tree
+equiv_opt -assert opt_balance_tree
+
+design -load postopt
+select -assert-count 3 t:$and
+
+# Checks if x[1] is still wired up to the correct gate
+select -set target_drivers o:x %ci %ci
+select -set target_cells t:$and @target_drivers %i
+select -set inputs @target_cells %ci
+select -assert-count 1 @inputs i:c %i
+
+design -reset
+log -pop
+
+log -header "Fanout going to multiple outputs"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire [2:0] x,
+  output wire y
+);
+  assign x[0] = a & b;
+  assign x[1] = x[0] & c;
+  assign x[2] = x[1] & d;
+
+  assign y = x[1];
 endmodule
 EOF
 check -assert
@@ -164,33 +202,12 @@ equiv_opt -assert opt_balance_tree
 design -load postopt
 select -assert-count 3 t:$and
 
-design -reset
-log -pop
-
-log -header "Fanout going to multiple of the same word"
-log -push
-design -reset
-read_verilog <<EOF
-module top (
-  input wire a,
-  input wire b,
-  input wire c,
-  input wire d,
-  output wire [3:0] x
-);
-  assign x[0] = a & b;
-  assign x[1] = x[0] & c;
-  assign x[2] = x[1] & d;
-  assign x[3] = x[1];
-endmodule
-EOF
-check -assert
-
-# Check equivalence after opt_balance_tree
-equiv_opt -assert opt_balance_tree
-
-design -load postopt
-select -assert-count 3 t:$and
+# Checks if y is still wired up to the correct gate
+select -set y_wires o:y %ci
+select -set y_driver @y_wires %ci %ci
+select -set and_y_cell t:$and @y_driver %i
+select -set inputs @and_y_cell %ci
+select -assert-count 1 @inputs i:c %i
 
 design -reset
 log -pop
@@ -222,45 +239,37 @@ design -load postopt
 # Checks if inputs to and gates has been rewired
 
 # a and b
-select -set a_wires i:a %co
-select -set driven_by_a @a_wires %co
+select -set driven_by_a i:a %co %co
 select -set and_a_cell t:$and @driven_by_a %i
 
-select -set b_wires i:b %co
-select -set driven_by_b @b_wires %co
+select -set driven_by_b i:b %co %co
 select -set and_b_cell t:$and @driven_by_b %i
 
 select -assert-none @and_a_cell @and_b_cell %d
 
 # c and d
-select -set c_wires i:c %co
-select -set driven_by_c @c_wires %co
+select -set driven_by_c i:c %co %co
 select -set and_c_cell t:$and @driven_by_c %i
 
-select -set d_wires i:d %co
-select -set driven_by_d @d_wires %co
+select -set driven_by_d i:d %co %co
 select -set and_d_cell t:$and @driven_by_d %i
 
 select -assert-none @and_c_cell @and_d_cell %d
 
 # e and f
-select -set e_wires i:e %co
-select -set driven_by_e @e_wires %co
+select -set driven_by_e i:e %co %co
 select -set and_e_cell t:$and @driven_by_e %i
 
-select -set f_wires i:f %co
-select -set driven_by_f @f_wires %co
+select -set driven_by_f i:f %co %co
 select -set and_f_cell t:$and @driven_by_f %i
 
 select -assert-none @and_e_cell @and_f_cell %d
 
 # g and h
-select -set g_wires i:g %co
-select -set driven_by_g @g_wires %co
+select -set driven_by_g i:g %co %co
 select -set and_g_cell t:$and @driven_by_g %i
 
-select -set h_wires i:h %co
-select -set driven_by_h @h_wires %co
+select -set driven_by_h i:h %co %co
 select -set and_h_cell t:$and @driven_by_h %i
 
 select -assert-none @and_g_cell @and_h_cell %d

--- a/tests/silimate/opt_balance_tree.ys
+++ b/tests/silimate/opt_balance_tree.ys
@@ -14,27 +14,31 @@ endmodule
 EOF
 check -assert
 
-autoname
-write_json pre.json
-exec -- netlistsvg pre.json -o pre.svg
-
 # Check equivalence after opt_balance_tree
 equiv_opt -assert opt_balance_tree
 
 design -load postopt
-# opt_balance_tree
 
-autoname
-write_json post.json
-exec -- netlistsvg post.json -o post.svg
+# Checks if inputs to and gates has been rewired
+select -set a_wires i:a %co
+select -set driven_by_a @a_wires %co
+select -set and_a_cell t:$and @driven_by_a %i
 
-# Checks if y is still wired up to the correct gate
-# select -set y_wires o:y %ci
-# select -set y_driver @y_wires %ci
-# select -set and_y_cell t:$and @y_driver %i
-# select @and_y_cell -assert-count 1
-# select -set inputs @and_y_cell %ci
-# select -assert-count 1 @inputs i:c %i
+select -set b_wires i:b %co
+select -set driven_by_b @b_wires %co
+select -set and_b_cell t:$and @driven_by_b %i
+
+select -assert-none @and_a_cell @and_b_cell %d
+
+select -set c_wires i:c %co
+select -set driven_by_c @c_wires %co
+select -set and_c_cell t:$and @driven_by_c %i
+
+select -set d_wires i:d %co
+select -set driven_by_d @d_wires %co
+select -set and_d_cell t:$and @driven_by_d %i
+
+select -assert-none @and_c_cell @and_d_cell %d
 
 design -reset
 log -pop
@@ -187,6 +191,79 @@ equiv_opt -assert opt_balance_tree
 
 design -load postopt
 select -assert-count 3 t:$and
+
+design -reset
+log -pop
+
+log -header "Interesting tree situation"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a, b, c, d,
+  input wire e, f, g, h,
+  output wire x,
+);
+  wire i, j;
+
+  assign i = a & b & c & d;
+  assign j = e & f & g & h & i;
+
+  assign x = i & j;
+endmodule
+EOF
+check -assert
+
+# Check equivalence after opt_balance_tree
+equiv_opt -assert opt_balance_tree
+
+design -load postopt
+
+# Checks if inputs to and gates has been rewired
+
+# a and b
+select -set a_wires i:a %co
+select -set driven_by_a @a_wires %co
+select -set and_a_cell t:$and @driven_by_a %i
+
+select -set b_wires i:b %co
+select -set driven_by_b @b_wires %co
+select -set and_b_cell t:$and @driven_by_b %i
+
+select -assert-none @and_a_cell @and_b_cell %d
+
+# c and d
+select -set c_wires i:c %co
+select -set driven_by_c @c_wires %co
+select -set and_c_cell t:$and @driven_by_c %i
+
+select -set d_wires i:d %co
+select -set driven_by_d @d_wires %co
+select -set and_d_cell t:$and @driven_by_d %i
+
+select -assert-none @and_c_cell @and_d_cell %d
+
+# e and f
+select -set e_wires i:e %co
+select -set driven_by_e @e_wires %co
+select -set and_e_cell t:$and @driven_by_e %i
+
+select -set f_wires i:f %co
+select -set driven_by_f @f_wires %co
+select -set and_f_cell t:$and @driven_by_f %i
+
+select -assert-none @and_e_cell @and_f_cell %d
+
+# g and h
+select -set g_wires i:g %co
+select -set driven_by_g @g_wires %co
+select -set and_g_cell t:$and @driven_by_g %i
+
+select -set h_wires i:h %co
+select -set driven_by_h @h_wires %co
+select -set and_h_cell t:$and @driven_by_h %i
+
+select -assert-none @and_g_cell @and_h_cell %d
 
 design -reset
 log -pop

--- a/tests/silimate/opt_balance_tree.ys
+++ b/tests/silimate/opt_balance_tree.ys
@@ -127,7 +127,7 @@ module top (
   input wire b,
   input wire c,
   input wire d,
-  output wire [3:0] x,
+  output wire [3:0] x
 );
   assign x[0] = a & b;
   assign x[1] = x[0] & c;

--- a/tests/silimate/opt_balance_tree.ys
+++ b/tests/silimate/opt_balance_tree.ys
@@ -1,3 +1,44 @@
+log -header "Should be turned into a tree"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire a,
+  input wire b,
+  input wire c,
+  input wire d,
+  output wire x,
+);
+  assign x = a & b & c & d;
+endmodule
+EOF
+check -assert
+
+autoname
+write_json pre.json
+exec -- netlistsvg pre.json -o pre.svg
+
+# Check equivalence after opt_balance_tree
+equiv_opt -assert opt_balance_tree
+
+design -load postopt
+# opt_balance_tree
+
+autoname
+write_json post.json
+exec -- netlistsvg post.json -o post.svg
+
+# Checks if y is still wired up to the correct gate
+# select -set y_wires o:y %ci
+# select -set y_driver @y_wires %ci
+# select -set and_y_cell t:$and @y_driver %i
+# select @and_y_cell -assert-count 1
+# select -set inputs @and_y_cell %ci
+# select -assert-count 1 @inputs i:c %i
+
+design -reset
+log -pop
+
 log -header "Should not be turned into a tree"
 log -push
 design -reset
@@ -18,11 +59,18 @@ endmodule
 EOF
 check -assert
 
-# Check equivalence after opt_expand
+# Check equivalence after opt_balance_tree
 equiv_opt -assert opt_balance_tree
 
-# TODO check design to make sure that it is not turned into a tree
-# design -load postopt
+design -load postopt
+
+# Checks if y is still wired up to the correct gate
+select -set y_wires o:y %ci
+select -set y_driver @y_wires %ci
+select -set and_y_cell t:$and @y_driver %i
+select @and_y_cell -assert-count 1
+select -set inputs @and_y_cell %ci
+select -assert-count 1 @inputs i:c %i
 
 design -reset
 log -pop
@@ -49,12 +97,11 @@ endmodule
 EOF
 check -assert
 
-# Check equivalence after opt_expand
+# Check equivalence after opt_balance_tree
 equiv_opt -assert opt_balance_tree
 
-# TODO check design to make sure that it is not turned into a tree
-# Note: this one already worked, just including here for completeness
-# design -load postopt
+design -load postopt
+select -assert-count 3 t:$and
 
 design -reset
 log -pop
@@ -77,12 +124,11 @@ endmodule
 EOF
 check -assert
 
-# Check equivalence after opt_expand
+# Check equivalence after opt_balance_tree
 equiv_opt -assert opt_balance_tree
 
-# TODO check design to make sure that it is not turned into a tree
-# Note: this one already worked, just including here for completeness
-# design -load postopt
+design -load postopt
+select -assert-count 3 t:$and
 
 design -reset
 log -pop
@@ -108,12 +154,11 @@ endmodule
 EOF
 check -assert
 
-# Check equivalence after opt_expand
+# Check equivalence after opt_balance_tree
 equiv_opt -assert opt_balance_tree
 
-# TODO check design to make sure that it is not turned into a tree
-# Note: this one already worked, just including here for completeness
-# design -load postopt
+design -load postopt
+select -assert-count 3 t:$and
 
 design -reset
 log -pop
@@ -137,12 +182,11 @@ endmodule
 EOF
 check -assert
 
-# Check equivalence after opt_expand
+# Check equivalence after opt_balance_tree
 equiv_opt -assert opt_balance_tree
 
-# TODO check design to make sure that it is not turned into a tree
-# Note: this one already worked, just including here for completeness
-# design -load postopt
+design -load postopt
+select -assert-count 3 t:$and
 
 design -reset
 log -pop


### PR DESCRIPTION
Seems to be an issue with opt_balance_tree. These tests are failing. 

Note: 
- These tests need to be written more thoroughly
- More tests need to be added to test opt_balance_tree

Updated Pull Request to have changes to the modified opt_balance_tree pass and brought back wire renaming so formal check can pass. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds failing `opt_balance_tree` tests in `tests/silimate/opt_balance_tree.ys` with various scenarios and TODOs for further development.
> 
>   - **Tests**:
>     - Adds `opt_balance_tree` tests in `tests/silimate/opt_balance_tree.ys`.
>     - Tests include scenarios: simple module, module with cell, word out port, fanout to multiple outputs, and fanout to multiple of the same word.
>     - Tests are currently failing and need more thorough writing and additional cases.
>     - Includes TODOs to verify designs are not turned into a tree.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fyosys&utm_source=github&utm_medium=referral)<sup> for d10e42c4bf3c1e739f699db8599cef7143a7ba4e. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->