### PR TITLE
Fix getPort issue for yosys tests

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1208,7 +1208,9 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		dict<std::string, int> cell_stats;
 		for (auto c : mapped_mod->cells())
 		{
-			c->attributes = sig_to_driver_attrs[mapped_sigmap(module->wire(remap_name(c->getPort(ID::Y).as_wire()->name)))];
+			// SILIMATE: set output port to either Y or Q depending on the cell's ports
+			RTLIL::IdString output_port_name = (c->hasPort(ID::Y)) ? ID::Y : ID::Q;
+			c->attributes = sig_to_driver_attrs[mapped_sigmap(module->wire(remap_name(c->getPort(output_port_name).as_wire()->name)))];
 			if (builtin_lib)
 			{
 				cell_stats[RTLIL::unescape_id(c->type)]++;


### PR DESCRIPTION
* Fixes issue in abc.cc with cells that have an output port not named Y (sequential cells). 
* Passes Yosys-tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes output port handling in `abc.cc` for cells without `Y` port by using `Q` if available, ensuring correct attribute assignment.
> 
>   - **Behavior**:
>     - Fixes issue in `abc.cc` for cells with output ports not named `Y` by checking for `Y` or `Q` and setting the output port accordingly.
>     - Ensures correct attribute assignment for sequential cells.
>     - Passes Yosys tests to verify the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fyosys&utm_source=github&utm_medium=referral)<sup> for 093bf7ed7e31d8fa8479be888d6720d78de309aa. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->