### PR TITLE
read_liberty2json: propagate src attribute if available

### DIFF
--- a/passes/silimate/l2j_frontend.cc
+++ b/passes/silimate/l2j_frontend.cc
@@ -391,6 +391,11 @@ struct L2JFrontend : public Frontend {
 			current_module->set_string_attribute(ID(LeakagePower), std::to_string(cell_leakage_power));
 			current_module->set_string_attribute(ID(leakage_power_unit), leakage_power_unit);
 
+			if (cell.count("src")) {
+				auto src_attr = get_string_attr(cell_desc + " src attribute", cell, "src", "");
+				current_module->set_src_attribute(src_attr);
+			}
+
 			size_t group_idx = 0;
 			size_t pin_idx = 0;
 			size_t bus_idx = 0;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Propagate `src` attribute from JSON `cell` object to `current_module` in `L2JFrontend::execute` if it exists.
> 
>   - **Behavior**:
>     - In `L2JFrontend::execute`, propagate `src` attribute from JSON `cell` object to `current_module` if it exists.
>     - Uses `get_string_attr` to retrieve `src` attribute value.
>   - **Misc**:
>     - No changes to existing functionality, only addition of `src` attribute handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fyosys&utm_source=github&utm_medium=referral)<sup> for 074fef93c9dcb8e48ee43f50e0cbb7834565d84b. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->