### PR TITLE
[ENG-1923] - Splitcells pass overlap bug

### DIFF
--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -211,9 +211,9 @@ struct SplitcellsWorker
 							if (bracket_pos != std::string::npos) {
 									wire_indices = wire_name.substr(bracket_pos) + stringf(
 										"%c%d%c", format[0], bit_offset, format[1]);
-							} else { // no brackets, so no concatenation using wire, use slice_lsb instead
+							} else { // no brackets, so no concatenation using wire, use slice_lsb + name_lsb offset instead
 									wire_indices = stringf(
-										"%c%d%c", format[0], slice_lsb, format[1]);
+										"%c%d%c", format[0], slice_lsb + name_lsb, format[1]);
 							}
 					} else {
 							// Fallback

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -202,22 +202,19 @@ struct SplitcellsWorker
 							Wire *w = raw_q[slice_lsb].wire;
 							std::string wire_name = w->name.str();
 
-							// Extract bit offset from the wire (ex: 0)
-							int bit_offset = user_index(slice_lsb);
-
 							// Concatenate wire index (ex: \Memory[0] -> [0]) to the bit offset (ex: [0][bit])
 							size_t bracket_pos = wire_name.find('[');
 							if (bracket_pos != std::string::npos) {
 									wire_indices = wire_name.substr(bracket_pos) + stringf(
-										"%c%d%c", format[0], bit_offset, format[1]);
+										"%c%d%c", format[0], slice_lsb, format[1]);
 							} else { // no brackets, so no concatenation
 									wire_indices = stringf(
-										"%c%d%c", format[0], bit_offset, format[1]);
+										"%c%d%c", format[0], slice_lsb, format[1]);
 							}
 					} else {
 							// Fallback
 							wire_indices = stringf(
-								"%c%d%c", format[0], name_lsb, format[1]);
+								"%c%d%c", format[0], slice_lsb, format[1]);
 					}
 					// Construct uniquified name by concatenating the base name with the wire indices
 					slice_name = module->uniquify(base_name + wire_indices);

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -187,6 +187,7 @@ struct SplitcellsWorker
 
 				std::string base_name = cell->name.str();
 				IdString slice_name;
+
 				if (blast) {
 					// Strip existing brackets from cell name
 					size_t bracket_pos = base_name.find('[');
@@ -202,12 +203,15 @@ struct SplitcellsWorker
 							Wire *w = raw_q[slice_lsb].wire;
 							std::string wire_name = w->name.str();
 
+							// Extract bit offset from the wire (ex: 0)
+							int bit_offset = user_index(slice_lsb);
+
 							// Concatenate wire index (ex: \Memory[0] -> [0]) to the bit offset (ex: [0][bit])
 							size_t bracket_pos = wire_name.find('[');
 							if (bracket_pos != std::string::npos) {
 									wire_indices = wire_name.substr(bracket_pos) + stringf(
-										"%c%d%c", format[0], slice_lsb, format[1]);
-							} else { // no brackets, so no concatenation
+										"%c%d%c", format[0], bit_offset, format[1]);
+							} else { // no brackets, so no concatenation using wire, use slice_lsb instead
 									wire_indices = stringf(
 										"%c%d%c", format[0], slice_lsb, format[1]);
 							}

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -177,6 +177,7 @@ struct SplitcellsWorker
 			slices.push_back(GetSize(outsig));
 
 			log_debug("Splitting %s cell %s/%s into %d slices:\n", log_id(cell->type), log_id(module), log_id(cell), GetSize(slices)-1);
+			int wire_offset = user_index(0);
 			for (int i = 1; i < GetSize(slices); i++)
 			{
 				int slice_msb = slices[i]-1;
@@ -184,10 +185,8 @@ struct SplitcellsWorker
 				int name_lsb = user_index(slice_lsb);
 				int name_msb = user_index(slice_msb);
 				if (name_lsb > name_msb) std::swap(name_lsb, name_msb);
-
 				std::string base_name = cell->name.str();
 				IdString slice_name;
-
 				if (blast) {
 					// Strip existing brackets from cell name
 					size_t bracket_pos = base_name.find('[');
@@ -213,7 +212,7 @@ struct SplitcellsWorker
 										"%c%d%c", format[0], bit_offset, format[1]);
 							} else { // no brackets, so no concatenation using wire, use slice_lsb + name_lsb offset instead
 									wire_indices = stringf(
-										"%c%d%c", format[0], slice_lsb + name_lsb, format[1]);
+										"%c%d%c", format[0], slice_lsb + wire_offset, format[1]);
 							}
 					} else {
 							// Fallback

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -218,7 +218,7 @@ struct SplitcellsWorker
 					} else {
 							// Fallback
 							wire_indices = stringf(
-								"%c%d%c", format[0], slice_lsb, format[1]);
+								"%c%d%c", format[0], name_lsb, format[1]);
 					}
 					// Construct uniquified name by concatenating the base name with the wire indices
 					slice_name = module->uniquify(base_name + wire_indices);


### PR DESCRIPTION
'splitcells' pass should use slice_lsb and offset in all scenarios in bit blasting EXCEPT if we must use the index of the output Q pin (for N-dim ramnet naming issue referenced before).