### PR TITLE
[CUS-515] - Add '-unignore_module' flag

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3928,7 +3928,7 @@ struct VerificPass : public Pass {
 		if (GetSize(args) > argidx && args[argidx] == "-unignore_module") {
 			Set *ignored = veri_file::GetIgnoredModuleSet();
 			for (argidx++; argidx < GetSize(args); argidx++) {
-				string name = args[argidx].c_str();
+				const char *name = args[argidx].c_str();
 				if (ignored)
 					ignored->Remove(name);
 			}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3925,18 +3925,12 @@ struct VerificPass : public Pass {
 			goto check_error;
 		}
 
-		if (GetSize(args) > argidx && args[argidx] == "-delete_module") {
-			string lib = "work";
+		if (GetSize(args) > argidx && args[argidx] == "-unignore_module") {
 			Set *ignored = veri_file::GetIgnoredModuleSet();
 			for (argidx++; argidx < GetSize(args); argidx++) {
-				if (args[argidx] == "-work" && argidx+1 < GetSize(args)) {
-					lib = args[++argidx];
-					continue;
-				}
 				const char *name = args[argidx].c_str();
 				if (ignored)
 					ignored->Remove(name);
-				veri_file::RemoveModule(name, lib.c_str());
 			}
 			goto check_error;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3928,7 +3928,7 @@ struct VerificPass : public Pass {
 		if (GetSize(args) > argidx && args[argidx] == "-unignore_module") {
 			Set *ignored = veri_file::GetIgnoredModuleSet();
 			for (argidx++; argidx < GetSize(args); argidx++) {
-				const char *name = args[argidx].c_str();
+				string *name = args[argidx].c_str();
 				if (ignored)
 					ignored->Remove(name);
 			}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3928,7 +3928,7 @@ struct VerificPass : public Pass {
 		if (GetSize(args) > argidx && args[argidx] == "-unignore_module") {
 			Set *ignored = veri_file::GetIgnoredModuleSet();
 			for (argidx++; argidx < GetSize(args); argidx++) {
-				string *name = args[argidx].c_str();
+				string name = args[argidx].c_str();
 				if (ignored)
 					ignored->Remove(name);
 			}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -47,6 +47,7 @@ USING_YOSYS_NAMESPACE
 
 #include "Array.h"
 #include "RuntimeFlags.h"
+#include "Set.h" 
 #ifdef VERIFIC_HIER_TREE_SUPPORT
 #include "hier_tree.h"
 #endif
@@ -3920,6 +3921,22 @@ struct VerificPass : public Pass {
 			for (argidx++; argidx < GetSize(args); argidx++) {
 				string name = args[argidx];
 				veri_file::AddToIgnoredParsedModuleNames(name.c_str());
+			}
+			goto check_error;
+		}
+
+		if (GetSize(args) > argidx && args[argidx] == "-delete_module") {
+			string lib = "work";
+			Set *ignored = veri_file::GetIgnoredModuleSet();
+			for (argidx++; argidx < GetSize(args); argidx++) {
+				if (args[argidx] == "-work" && argidx+1 < GetSize(args)) {
+					lib = args[++argidx];
+					continue;
+				}
+				const char *name = args[argidx].c_str();
+				if (ignored)
+					ignored->Remove(name);
+				veri_file::RemoveModule(name, lib.c_str());
 			}
 			goto check_error;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -47,7 +47,7 @@ USING_YOSYS_NAMESPACE
 
 #include "Array.h"
 #include "RuntimeFlags.h"
-#include "Set.h" 
+#include "Set.h"
 #ifdef VERIFIC_HIER_TREE_SUPPORT
 #include "hier_tree.h"
 #endif


### PR DESCRIPTION
Removes a module from verific parse tree and from ignore list if it is deleted.

Allows us to re-read a module definition (macro or simulation file)