### PR TITLE
[CUS-514] Reg rename fixes

### DIFF
--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -188,8 +188,8 @@ struct SplitcellsWorker
 				std::string base_name = cell->name.str();
 				IdString slice_name;
 				if (blast) {
-					// Strip existing brackets from cell name
-					size_t bracket_pos = base_name.find('[');
+					// Strip existing '[' or '.' from cell name
+					size_t bracket_pos = base_name.find_first_of('[.');
 					if (bracket_pos != std::string::npos) {
 						base_name = base_name.substr(0, bracket_pos);
 					}
@@ -205,12 +205,12 @@ struct SplitcellsWorker
 							// Extract bit offset from the wire (ex: 0)
 							int bit_offset = user_index(slice_lsb);
 
-							// Concatenate wire index (ex: \Memory[0] -> [0]) to the bit offset (ex: [0][bit])
-							size_t bracket_pos = wire_name.find('[');
+							// Concatenate struct attribute or wire index (ex: \Memory[0] -> [0]) to the bit offset
+							size_t bracket_pos = wire_name.find_first_of('[.');
 							if (bracket_pos != std::string::npos) {
 									wire_indices = wire_name.substr(bracket_pos) + stringf(
 										"%c%d%c", format[0], bit_offset, format[1]);
-							} else { // no brackets, so no concatenation using wire, use slice_lsb + name_lsb offset instead
+							} else { // no '[' or '.', so no concatenation using wire, use slice_lsb + name_lsb offset instead
 									wire_indices = stringf(
 										"%c%d%c", format[0], slice_lsb + wire_offset, format[1]);
 							}

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -216,7 +216,7 @@ struct SplitcellsWorker
 							// Concatenate struct attribute or wire index (ex: \Memory[0] -> [0]) to the bit offset
 							size_t bracket_pos = wire_name.find_first_of("[.");
 							if (bracket_pos != std::string::npos) {
-									wire_indices = wire_name.substr(bracket_pos) + (strip_reg ? "" : "_reg") + stringf(
+									wire_indices = wire_name.substr(bracket_pos) + (strip_reg ? "_reg" : "") + stringf(
 										"%c%d%c", format[0], bit_offset, format[1]);
 							} else { // no '[' or '.', so no concatenation using wire, use slice_lsb + name_lsb offset instead
 									wire_indices = stringf(

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -189,8 +189,16 @@ struct SplitcellsWorker
 				IdString slice_name;
 				if (blast) {
 					// Strip existing '[' or '.' from cell name
-					size_t bracket_pos = base_name.find_first_of('[.');
+					size_t bracket_pos = base_name.find_first_of("[.");
+					bool strip_reg = false;
 					if (bracket_pos != std::string::npos) {
+
+						// Check if we will strip off _reg suffix
+						size_t reg_pos = base_name.find("_reg");
+						if (reg_pos != std::string::npos && reg_pos > bracket_pos) {
+							base_name = base_name.substr(0, reg_pos);
+							strip_reg = true;
+						}
 						base_name = base_name.substr(0, bracket_pos);
 					}
 
@@ -206,9 +214,9 @@ struct SplitcellsWorker
 							int bit_offset = user_index(slice_lsb);
 
 							// Concatenate struct attribute or wire index (ex: \Memory[0] -> [0]) to the bit offset
-							size_t bracket_pos = wire_name.find_first_of('[.');
+							size_t bracket_pos = wire_name.find_first_of("[.");
 							if (bracket_pos != std::string::npos) {
-									wire_indices = wire_name.substr(bracket_pos) + stringf(
+									wire_indices = wire_name.substr(bracket_pos) + (strip_reg ? "" : "_reg") + stringf(
 										"%c%d%c", format[0], bit_offset, format[1]);
 							} else { // no '[' or '.', so no concatenation using wire, use slice_lsb + name_lsb offset instead
 									wire_indices = stringf(

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -193,7 +193,7 @@ struct SplitcellsWorker
 					bool strip_reg = false;
 					if (bracket_pos != std::string::npos) {
 
-						// Check if we will strip off _reg suffix
+						// Check if we will strip off _reg suffix from base name
 						size_t reg_pos = base_name.find("_reg");
 						if (reg_pos != std::string::npos && reg_pos > bracket_pos) {
 							base_name = base_name.substr(0, reg_pos);
@@ -206,7 +206,7 @@ struct SplitcellsWorker
 					std::string wire_indices;
 					if (slice_lsb < GetSize(raw_q) && raw_q[slice_lsb].is_wire()) {
 
-							// Extract wire name (ex: \Memory[0])
+							// Extract wire name (ex: \Memory[0] or \Memory.attr)
 							Wire *w = raw_q[slice_lsb].wire;
 							std::string wire_name = w->name.str();
 

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -194,7 +194,7 @@ struct SplitcellsWorker
 					if (bracket_pos != std::string::npos) {
 
 						// Check if we will strip off _reg suffix from base name
-						size_t reg_pos = base_name.find("_reg");
+						size_t reg_pos = base_name.rfind("_reg");
 						if (reg_pos != std::string::npos && reg_pos > bracket_pos) {
 							base_name = base_name.substr(0, reg_pos);
 							strip_reg = true;

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -108,16 +108,10 @@ struct RegRenameInstance {
 				size_t last_open = cellName.rfind('[');
 				size_t last_close = cellName.rfind(']');
 				if (last_open != std::string::npos && last_close != std::string::npos && last_close > last_open) {
-
-						// Check that bracket content is just a single bit index
-						std::string inner = cellName.substr(last_open + 1, last_close - last_open - 1);
-						if (!inner.empty() && inner.find_first_not_of("0123456789") == std::string::npos) {
-							wireName = cellName.substr(0, last_open);
-							bitIndex = std::stoi(inner);
-						} else {
-							wireName = cellName;
-							bitIndex = 0;
-						}
+					// Check that bracket content is just a single bit index
+					std::string inner = cellName.substr(last_open + 1, last_close - last_open - 1);
+					wireName = cellName.substr(0, last_open);
+					bitIndex = std::stoi(inner);
 				} else {
 					wireName = cellName;
 					bitIndex = 0;
@@ -312,13 +306,9 @@ struct RegRenamePass : public Pass {
 					if (!signal_name.empty() && signal_name.back() == ']') {
 						size_t open = signal_name.rfind('[');
 						if (open != std::string::npos) {
-							std::string inner = signal_name.substr(open + 1,
-																										signal_name.size() - open - 2);
-							// Check for alphabetical characters since they can be contained in brackets in a wire name.
-							if (!inner.empty() && inner.find_first_not_of("0123456789:") == std::string::npos) {
-								signal_bits = signal_name.substr(open);
-								signal_name.erase(open);
-							}
+							std::string inner = signal_name.substr(open + 1, signal_name.size() - open - 2);
+							signal_bits = signal_name.substr(open);
+							signal_name.erase(open);
 						}
 					}
 

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -305,7 +305,6 @@ struct RegRenamePass : public Pass {
 					if (!signal_name.empty() && signal_name.back() == ']') {
 						size_t open = signal_name.rfind('[');
 						if (open != std::string::npos) {
-							std::string inner = signal_name.substr(open + 1, signal_name.size() - open - 2);
 							signal_bits = signal_name.substr(open);
 							signal_name.erase(open);
 						}

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -128,7 +128,7 @@ struct RegRenameInstance {
 
 					int wireWidth = regInfo.width;
 					int wireOffset = regInfo.offset;
-					if (wireWidth == 0 && regName.find("_reg") != std::string::npos) {
+					if (wireWidth == 0) {
 						log_warning("Unable to find matching register %s in VCD for cell %s in scope %s\n",
 							regName.c_str(), cellName.c_str(), vcd_scope.c_str());
 						continue;

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -108,11 +108,19 @@ struct RegRenameInstance {
 				size_t last_open = cellName.rfind('[');
 				size_t last_close = cellName.rfind(']');
 				if (last_open != std::string::npos && last_close != std::string::npos && last_close > last_open) {
-						wireName = cellName.substr(0, last_open);
-						bitIndex = std::stoi(cellName.substr(last_open + 1, last_close - last_open - 1));
+
+						// Check that bracket content is just a single bit index
+						std::string inner = cellName.substr(last_open + 1, last_close - last_open - 1);
+						if (!inner.empty() && inner.find_first_not_of("0123456789") == std::string::npos) {
+							wireName = cellName.substr(0, last_open);
+							bitIndex = std::stoi(inner);
+						} else {
+							wireName = cellName;
+							bitIndex = 0;
+						}
 				} else {
-						wireName = cellName;
-						bitIndex = 0;
+					wireName = cellName;
+					bitIndex = 0;
 				}
 
 				// Process Q output connection for the cell
@@ -301,10 +309,17 @@ struct RegRenamePass : public Pass {
 					std::string signal_bits = "";
 
 					// Use the bracket notation to extract the bit range and construct true reg name.
-					size_t bit_pos = signal_name.rfind('[');
-					if (bit_pos != std::string::npos) {
-						signal_bits = signal_name.substr(bit_pos);
-						signal_name.erase(bit_pos);
+					if (!signal_name.empty() && signal_name.back() == ']') {
+						size_t open = signal_name.rfind('[');
+						if (open != std::string::npos) {
+							std::string inner = signal_name.substr(open + 1,
+																										signal_name.size() - open - 2);
+							// Check for alphabetical characters since they can be contained in brackets in a wire name.
+							if (!inner.empty() && inner.find_first_not_of("0123456789:") == std::string::npos) {
+								signal_bits = signal_name.substr(open);
+								signal_name.erase(open);
+							}
+						}
 					}
 
 					// Extract the LSB and MSB indices if present.

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -64,7 +64,7 @@ struct RegRenameInstance {
 
 	// Processes registers in a given module hierarchy
 	// and renames to allow for correct register annotation
-	void process_registers(dict<std::pair<std::string, std::string>, RegInfo> &vcd_reg_widths)
+	void process_registers(dict<std::string, RegInfo> &vcd_reg_widths)
 	{
 		if (debug)
 			log("Processing registers in scope: %s (module: %s)\n", 
@@ -125,7 +125,7 @@ struct RegRenameInstance {
 
 					// Lookup wire information from VCD
 					std::string regName = RTLIL::unescape_id(wireName);
-					RegInfo regInfo = vcd_reg_widths[{vcd_scope, regName}];
+					RegInfo regInfo = vcd_reg_widths[vcd_scope + "." + regName];
 
 					int wireWidth = regInfo.width;
 					int wireOffset = regInfo.offset;
@@ -219,7 +219,7 @@ struct RegRenameInstance {
 		module->remove(wireRemoveCache);
 	}
 
-	void process_all(dict<std::pair<std::string, std::string>, RegInfo> &vcd_reg_widths)
+	void process_all(dict<std::string, RegInfo> &vcd_reg_widths)
 	{
 		process_registers(vcd_reg_widths);
 		for (auto &it : children)
@@ -281,7 +281,7 @@ struct RegRenamePass : public Pass {
 			log_error("No top module found!\n");
 
 		// Extract pre-optimization signal widths from VCD file
-		dict<std::pair<std::string, std::string>, RegInfo> vcd_reg_widths;
+		dict<std::string, RegInfo> vcd_reg_widths;
 		if (!vcd_filename.empty()) {
 			log("Reading VCD file: %s\n", vcd_filename.c_str());
 			try {
@@ -327,7 +327,7 @@ struct RegRenamePass : public Pass {
 					// Map the register's vcd scope and name to
 					// its original width and offset for later lookup.
 					signal_name = RTLIL::unescape_id(signal_name);
-					vcd_reg_widths[{vcd_scope, signal_name}] = {width, offset};
+					vcd_reg_widths[vcd_scope + "." + signal_name] = {width, offset};
 					if (debug)
 						log("Found signal '%s' in scope '%s' with range [%d:%d] (width %d)\n",
 							signal_name.c_str(), vcd_scope.c_str(),

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -128,7 +128,7 @@ struct RegRenameInstance {
 
 					int wireWidth = regInfo.width;
 					int wireOffset = regInfo.offset;
-					if (wireWidth == 0) {
+					if (wireWidth == 0 && regName.find("_reg") != std::string::npos) {
 						log_warning("Unable to find matching register %s in VCD for cell %s in scope %s\n",
 							regName.c_str(), cellName.c_str(), vcd_scope.c_str());
 						continue;

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -103,18 +103,17 @@ struct RegRenameInstance {
 				cellName.erase(reg_pos, 4);
 
 				// Index comes from the right-most brackets
-				std::string wireName;
+				std::string wireName = cellName;
 				int bitIndex = 0;
 				size_t last_open = cellName.rfind('[');
 				size_t last_close = cellName.rfind(']');
 				if (last_open != std::string::npos && last_close != std::string::npos && last_close > last_open) {
-					// Check that bracket content is just a single bit index
+					// Validate bracket content is just a single bit slice
 					std::string inner = cellName.substr(last_open + 1, last_close - last_open - 1);
-					wireName = cellName.substr(0, last_open);
-					bitIndex = std::stoi(inner);
-				} else {
-					wireName = cellName;
-					bitIndex = 0;
+					if (!inner.empty() && inner.find_first_not_of("0123456789") == std::string::npos) {
+						wireName = cellName.substr(0, last_open);
+						bitIndex = std::stoi(inner);
+					}
 				}
 
 				// Process Q output connection for the cell


### PR DESCRIPTION
1. Validation inside [] in RTL names to ensure that stoi does not throw a value error.
2. Flattened signal scope paths in vcd_reg_widths to allow for VCD and RTL hierarchies to match exactly when parsing VCDs and managing RTL hierarchies (particularly important for structs or fork scopes)
3. edited splitcells to properly handle struct attributes in registers, again using the Q wire name as a reference point instead of the register name itself (for renaming purposes) because the register name can't capture enough information about the struct.