### PR TITLE
Fix: don't log error when getting non-top cells in -bb mode

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -649,10 +649,11 @@ struct SimInstance
 		if (cell->type == ID($print))
 			return;
 
-		// If the cell is a blackbox child of an instance root module, skip it
+		// In -bb mode every hierarchical cell is a cut boundary. Its outputs were already sourced from the FST.
+		// Don't log error for these cells.
 		if (shared->blackbox_children) {
 			Module *mod = module->design->module(cell->type);
-			if (mod && shared->instance_root_modules.count(mod->name))
+			if (mod)
 				return;
 		}
 


### PR DESCRIPTION
Patch for PR#162. 
`update_cell` is called when the update phase traverses all top modules and their submodules. Top modules are updated and the function returns. Submodules don't need to be updated (their values come from FST), so they need to be skipped. The cells that are not in module->design->module should still trigger the error.