### PR TITLE
[CUS-538] - $fork scope union struct support

### DIFF
--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -182,7 +182,7 @@ void FstData::extractVarNames()
 					fork_parent_scope = fst_scope_name;
 					fork_name = h->u.scope.name;
 					fork_vars.clear();
-				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_STRUCT) {
+				} else if (in_fork && h->u.scope.typ == FST_ST_VCD_STRUCT) {
 					// Signal that a nested $fork can not be a candidate for union struct detection.
 					log_warning("Nested $fork '%s' inside $fork '%s'; "
 						"abandoning union detection for this scope...\n",

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -195,25 +195,32 @@ void FstData::extractVarNames()
 				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
 				break;
 			}
-			case FST_HT_SCOPE: {
-				// Handle tracking for potential union structs with $fork.
-				if (!detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
-					detect_union = true;
-					fork_parent_scope = fst_scope_name;
-					fork_name = h->u.scope.name;
-					fork_vars.clear();
-				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
-					// Nested $fork: abandon union detection. Warning is emitted
-					// at upscope time, only if the outer fork would have been a union.
-					for (auto &v : fork_vars) registerVar(v);
+			case FST_HT_UPSCOPE: {
+				if (detect_union) {
+					// A union is detected if there are at least 2 variables in the fork scope and they all have the same fstHandle.
+					bool is_union = fork_vars.size() >= 2 &&
+							std::all_of(fork_vars.begin() + 1, fork_vars.end(),
+									[&](const FstVar &v) { return v.id == fork_vars[0].id; });
+					if (is_union) {
+							// If a union, register the fork name as the variable at the parent scope.
+							FstVar u = fork_vars[0];
+							u.name = fork_name;
+							u.scope = fork_parent_scope;
+							normalize_brackets(u.scope);
+							u.is_alias = false;
+							registerVar(u);
+					} else {
+							// If not a union, register all variables in the fork scope as normal.
+							for (auto &v : fork_vars) {
+								registerVar(v);
+							}
+					}
 					detect_union = false;
 					fork_vars.clear();
-					fork_vars_had_nested_fork = true;
 				}
-				// Push the scope onto the stack to 'descend' into the hierarchy.
-				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
+				// Pop the scope off the stack.
+				fst_scope_name = fstReaderPopScope(ctx);
 				break;
-			}
 			}
 			case FST_HT_VAR: {
 				FstVar var;

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -168,7 +168,7 @@ void FstData::extractVarNames()
 	std::string fst_scope_name;
 
 	/* Variables for resolving unions with $fork. */
-	bool detect_union = false;      // if we should be detecting unions with $fork
+	bool in_fork = false;           // if we are inside a $fork scope
 	std::string fork_parent_scope;  // parent scope of fork (used to resolve union location)
 	std::string fork_name;          // name of fork (used to resolve union name)
 	std::vector<FstVar> fork_vars;  // stores all variables in the fork scope
@@ -177,18 +177,10 @@ void FstData::extractVarNames()
 		switch (h->htyp) {
 			case FST_HT_SCOPE: {
 				// Handle tracking for potential union structs with $fork.
-				if (!detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
-					detect_union = true;
+				if (!in_fork && h->u.scope.typ == FST_ST_VCD_FORK) {
+					in_fork = true;
 					fork_parent_scope = fst_scope_name;
 					fork_name = h->u.scope.name;
-					fork_vars.clear();
-				} else if (in_fork && h->u.scope.typ == FST_ST_VCD_STRUCT) {
-					// Signal that a nested $fork can not be a candidate for union struct detection.
-					log_warning("Nested $fork '%s' inside $fork '%s'; "
-						"abandoning union detection for this scope...\n",
-						h->u.scope.name, fork_name.c_str());
-					for (auto &v : fork_vars) registerVar(v);
-					detect_union = false;
 					fork_vars.clear();
 				}
 				// Push the scope onto the stack to 'descend' into the hierarchy.
@@ -196,7 +188,7 @@ void FstData::extractVarNames()
 				break;
 			}
 			case FST_HT_UPSCOPE: {
-				if (detect_union) {
+				if (in_fork) {
 					// A union is detected if there are at least 2 variables in the fork scope and they all have the same fstHandle.
 					bool is_union = fork_vars.size() >= 2 &&
 							std::all_of(fork_vars.begin() + 1, fork_vars.end(),
@@ -215,7 +207,7 @@ void FstData::extractVarNames()
 								registerVar(v);
 							}
 					}
-					detect_union = false;
+					in_fork = false;
 					fork_vars.clear();
 				}
 				// Pop the scope off the stack.
@@ -232,7 +224,7 @@ void FstData::extractVarNames()
 				normalize_brackets(var.scope);
 				var.width = h->u.var.length;
 
-				if (detect_union) fork_vars.push_back(var); // store all variables in fork scope into a vector
+				if (in_fork) fork_vars.push_back(var); // store all variables in fork scope into a vector
 				else registerVar(var); // otherwise, register the variable as normal
 				break;
 			}

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -182,26 +182,6 @@ void FstData::extractVarNames()
 					fork_parent_scope = fst_scope_name;
 					fork_name = h->u.scope.name;
 					fork_vars.clear();
-				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_STRUCT) {
-					// Signal that a nested $fork can not be a candidate for union struct detection.
-					log_warning("Nested $fork '%s' inside $fork '%s'; "
-						"abandoning union detection for this scope...\n",
-						h->u.scope.name, fork_name.c_str());
-					for (auto &v : fork_vars) registerVar(v);
-					detect_union = false;
-					fork_vars.clear();
-				}
-				// Push the scope onto the stack to 'descend' into the hierarchy.
-				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
-				break;
-			}
-			case FST_HT_SCOPE: {
-				// Handle tracking for potential union structs with $fork.
-				if (!detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
-					detect_union = true;
-					fork_parent_scope = fst_scope_name;
-					fork_name = h->u.scope.name;
-					fork_vars.clear();
 				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
 					// Nested $fork: abandon union detection. Warning is emitted
 					// at upscope time, only if the outer fork would have been a union.

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -182,6 +182,26 @@ void FstData::extractVarNames()
 					fork_parent_scope = fst_scope_name;
 					fork_name = h->u.scope.name;
 					fork_vars.clear();
+				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_STRUCT) {
+					// Signal that a nested $fork can not be a candidate for union struct detection.
+					log_warning("Nested $fork '%s' inside $fork '%s'; "
+						"abandoning union detection for this scope...\n",
+						h->u.scope.name, fork_name.c_str());
+					for (auto &v : fork_vars) registerVar(v);
+					detect_union = false;
+					fork_vars.clear();
+				}
+				// Push the scope onto the stack to 'descend' into the hierarchy.
+				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
+				break;
+			}
+			case FST_HT_SCOPE: {
+				// Handle tracking for potential union structs with $fork.
+				if (!detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
+					detect_union = true;
+					fork_parent_scope = fst_scope_name;
+					fork_name = h->u.scope.name;
+					fork_vars.clear();
 				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
 					// Nested $fork: abandon union detection. Warning is emitted
 					// at upscope time, only if the outer fork would have been a union.

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -182,7 +182,7 @@ void FstData::extractVarNames()
 					fork_parent_scope = fst_scope_name;
 					fork_name = h->u.scope.name;
 					fork_vars.clear();
-				} else if (in_fork && h->u.scope.typ == FST_ST_VCD_STRUCT) {
+				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_STRUCT) {
 					// Signal that a nested $fork can not be a candidate for union struct detection.
 					log_warning("Nested $fork '%s' inside $fork '%s'; "
 						"abandoning union detection for this scope...\n",

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -109,18 +109,108 @@ static std::string remove_spaces(std::string str)
 	return str;
 }
 
+void FstData::registerVar(const FstVar &var)
+{
+	vars.push_back(var);
+	if (!var.is_alias)
+		handle_to_var[var.id] = var;
+
+	std::string clean_name = var.name;
+	if (!clean_name.empty() && clean_name[0] == '\\')
+	clean_name = clean_name.substr(1);
+
+	// Strip trailing bit range [N:M] if present
+	if (!clean_name.empty() && clean_name.back() == ']') {
+		size_t open = clean_name.rfind('[');
+		if (open != std::string::npos) {
+			std::string inner = clean_name.substr(open + 1, clean_name.size() - open - 2);
+			if (inner.find(':') != std::string::npos)
+				clean_name.erase(open);
+		}
+	}
+
+	// Handle memory addresses
+	size_t pos = clean_name.find_last_of("<");
+	if (pos != std::string::npos && clean_name.back() == '>') {
+		std::string mem_cell = clean_name.substr(0, pos);
+		normalize_brackets(mem_cell);
+		std::string addr = clean_name.substr(pos+1);
+		addr.pop_back(); // remove closing bracket
+		char *endptr;
+		int mem_addr = strtol(addr.c_str(), &endptr, 16);
+		if (*endptr) {
+			log_debug("Error parsing memory address in : %s\n", clean_name);
+		} else {
+			memory_to_handle[var.scope+"."+mem_cell][mem_addr] = var.id;
+		}
+	}
+	pos = clean_name.find_last_of("[");
+	if (pos != std::string::npos && clean_name.back() == ']') {
+		std::string mem_cell = clean_name.substr(0, pos);
+		normalize_brackets(mem_cell);
+		std::string addr = clean_name.substr(pos+1);
+		addr.pop_back(); // remove closing bracket
+		char *endptr;
+		int mem_addr = strtol(addr.c_str(), &endptr, 10);
+		if (*endptr) {
+			log_debug("Error parsing memory address in : %s\n", clean_name);
+		} else {
+			memory_to_handle[var.scope+"."+mem_cell][mem_addr] = var.id;
+		}
+	}
+	normalize_brackets(clean_name);
+	name_to_handle[var.scope+"."+clean_name] = var.id;
+}
+
 void FstData::extractVarNames()
 {
 	struct fstHier *h;
 	std::string fst_scope_name;
 
+	/* Variables for resolving unions with $fork. */
+	bool in_fork = false;           // if we are inside a $fork scope
+	std::string fork_parent_scope;  // parent scope of fork (used to resolve union location)
+	std::string fork_name;          // name of fork (used to resolve union name)
+	std::vector<FstVar> fork_vars;  // stores all variables in the fork scope
+
 	while ((h = fstReaderIterateHier(ctx))) {
 		switch (h->htyp) {
 			case FST_HT_SCOPE: {
+				// Handle tracking for potential union structs with $fork.
+				if (!in_fork && h->u.scope.typ == FST_ST_VCD_FORK) {
+					in_fork = true;
+					fork_parent_scope = fst_scope_name;
+					fork_name = h->u.scope.name;
+					fork_vars.clear();
+				}
+				// Push the scope onto the stack to 'descend' into the hierarchy.
 				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
 				break;
 			}
 			case FST_HT_UPSCOPE: {
+				if (in_fork) {
+					// A union is detected if there are at least 2 variables in the fork scope and they all have the same fstHandle.
+					bool is_union = fork_vars.size() >= 2 &&
+							std::all_of(fork_vars.begin() + 1, fork_vars.end(),
+									[&](const FstVar &v) { return v.id == fork_vars[0].id; });
+					if (is_union) {
+							// If a union, register the fork name as the variable at the parent scope.
+							FstVar u = fork_vars[0];
+							u.name = fork_name;
+							u.scope = fork_parent_scope;
+							normalize_brackets(u.scope);
+							u.is_alias = false;
+							registerVar(u);
+					} else {
+							// If not a union, register all variables in the fork scope as normal.
+							for (auto &v : fork_vars) {
+								registerVar(v);
+							}
+					}
+					in_fork = false;
+					fork_vars.clear();
+				}
+				// Pop the scope off the stack.
 				fst_scope_name = fstReaderPopScope(ctx);
 				break;
 			}
@@ -133,61 +223,14 @@ void FstData::extractVarNames()
 				var.scope = fst_scope_name;
 				normalize_brackets(var.scope);
 				var.width = h->u.var.length;
-				vars.push_back(var);
-				if (!var.is_alias)
-					handle_to_var[h->u.var.handle] = var;
 
-				std::string clean_name = var.name;
-				if (!clean_name.empty() && clean_name[0] == '\\')
-				clean_name = clean_name.substr(1);
-
-				// Strip trailing bit range [N:M] if present
-				if (!clean_name.empty() && clean_name.back() == ']') {
-					size_t open = clean_name.rfind('[');
-					if (open != std::string::npos) {
-						std::string inner = clean_name.substr(open + 1, clean_name.size() - open - 2);
-						if (inner.find(':') != std::string::npos)
-							clean_name.erase(open);
-					}
-				}
-
-				// Handle memory addresses
-				size_t pos = clean_name.find_last_of("<");
-				if (pos != std::string::npos && clean_name.back() == '>') {
-					std::string mem_cell = clean_name.substr(0, pos);
-					normalize_brackets(mem_cell);
-					std::string addr = clean_name.substr(pos+1);
-					addr.pop_back(); // remove closing bracket
-					char *endptr;
-					int mem_addr = strtol(addr.c_str(), &endptr, 16);
-					if (*endptr) {
-						log_debug("Error parsing memory address in : %s\n", clean_name);
-					} else {
-						memory_to_handle[var.scope+"."+mem_cell][mem_addr] = var.id;
-					}
-				}
-				pos = clean_name.find_last_of("[");
-				if (pos != std::string::npos && clean_name.back() == ']') {
-					std::string mem_cell = clean_name.substr(0, pos);
-					normalize_brackets(mem_cell);
-					std::string addr = clean_name.substr(pos+1);
-					addr.pop_back(); // remove closing bracket
-					char *endptr;
-					int mem_addr = strtol(addr.c_str(), &endptr, 10);
-					if (*endptr) {
-						log_debug("Error parsing memory address in : %s\n", clean_name);
-					} else {
-						memory_to_handle[var.scope+"."+mem_cell][mem_addr] = var.id;
-					}
-				}
-				normalize_brackets(clean_name);
-				name_to_handle[var.scope+"."+clean_name] = h->u.var.handle;
+				if (in_fork) fork_vars.push_back(var); // store all variables in fork scope into a vector
+				else registerVar(var); // otherwise, register the variable as normal
 				break;
 			}
 		}
 	}
 }
-
 
 static void reconstruct_clb_varlen_attimes(void *user_data, uint64_t pnt_time, fstHandle pnt_facidx, const unsigned char *pnt_value, uint32_t plen)
 {

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -195,32 +195,25 @@ void FstData::extractVarNames()
 				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
 				break;
 			}
-			case FST_HT_UPSCOPE: {
-				if (detect_union) {
-					// A union is detected if there are at least 2 variables in the fork scope and they all have the same fstHandle.
-					bool is_union = fork_vars.size() >= 2 &&
-							std::all_of(fork_vars.begin() + 1, fork_vars.end(),
-									[&](const FstVar &v) { return v.id == fork_vars[0].id; });
-					if (is_union) {
-							// If a union, register the fork name as the variable at the parent scope.
-							FstVar u = fork_vars[0];
-							u.name = fork_name;
-							u.scope = fork_parent_scope;
-							normalize_brackets(u.scope);
-							u.is_alias = false;
-							registerVar(u);
-					} else {
-							// If not a union, register all variables in the fork scope as normal.
-							for (auto &v : fork_vars) {
-								registerVar(v);
-							}
-					}
+			case FST_HT_SCOPE: {
+				// Handle tracking for potential union structs with $fork.
+				if (!detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
+					detect_union = true;
+					fork_parent_scope = fst_scope_name;
+					fork_name = h->u.scope.name;
+					fork_vars.clear();
+				} else if (detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
+					// Nested $fork: abandon union detection. Warning is emitted
+					// at upscope time, only if the outer fork would have been a union.
+					for (auto &v : fork_vars) registerVar(v);
 					detect_union = false;
 					fork_vars.clear();
+					fork_vars_had_nested_fork = true;
 				}
-				// Pop the scope off the stack.
-				fst_scope_name = fstReaderPopScope(ctx);
+				// Push the scope onto the stack to 'descend' into the hierarchy.
+				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
 				break;
+			}
 			}
 			case FST_HT_VAR: {
 				FstVar var;

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -214,7 +214,6 @@ void FstData::extractVarNames()
 				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
 				break;
 			}
-			}
 			case FST_HT_VAR: {
 				FstVar var;
 				var.id = h->u.var.handle;

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -214,6 +214,7 @@ void FstData::extractVarNames()
 				fst_scope_name = fstReaderPushScope(ctx, h->u.scope.name, NULL);
 				break;
 			}
+			}
 			case FST_HT_VAR: {
 				FstVar var;
 				var.id = h->u.var.handle;

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -168,7 +168,7 @@ void FstData::extractVarNames()
 	std::string fst_scope_name;
 
 	/* Variables for resolving unions with $fork. */
-	bool in_fork = false;           // if we are inside a $fork scope
+	bool detect_union = false;      // if we should be detecting unions with $fork
 	std::string fork_parent_scope;  // parent scope of fork (used to resolve union location)
 	std::string fork_name;          // name of fork (used to resolve union name)
 	std::vector<FstVar> fork_vars;  // stores all variables in the fork scope
@@ -177,10 +177,18 @@ void FstData::extractVarNames()
 		switch (h->htyp) {
 			case FST_HT_SCOPE: {
 				// Handle tracking for potential union structs with $fork.
-				if (!in_fork && h->u.scope.typ == FST_ST_VCD_FORK) {
-					in_fork = true;
+				if (!detect_union && h->u.scope.typ == FST_ST_VCD_FORK) {
+					detect_union = true;
 					fork_parent_scope = fst_scope_name;
 					fork_name = h->u.scope.name;
+					fork_vars.clear();
+				} else if (in_fork && h->u.scope.typ == FST_ST_VCD_STRUCT) {
+					// Signal that a nested $fork can not be a candidate for union struct detection.
+					log_warning("Nested $fork '%s' inside $fork '%s'; "
+						"abandoning union detection for this scope...\n",
+						h->u.scope.name, fork_name.c_str());
+					for (auto &v : fork_vars) registerVar(v);
+					detect_union = false;
 					fork_vars.clear();
 				}
 				// Push the scope onto the stack to 'descend' into the hierarchy.
@@ -188,7 +196,7 @@ void FstData::extractVarNames()
 				break;
 			}
 			case FST_HT_UPSCOPE: {
-				if (in_fork) {
+				if (detect_union) {
 					// A union is detected if there are at least 2 variables in the fork scope and they all have the same fstHandle.
 					bool is_union = fork_vars.size() >= 2 &&
 							std::all_of(fork_vars.begin() + 1, fork_vars.end(),
@@ -207,7 +215,7 @@ void FstData::extractVarNames()
 								registerVar(v);
 							}
 					}
-					in_fork = false;
+					detect_union = false;
 					fork_vars.clear();
 				}
 				// Pop the scope off the stack.
@@ -224,7 +232,7 @@ void FstData::extractVarNames()
 				normalize_brackets(var.scope);
 				var.width = h->u.var.length;
 
-				if (in_fork) fork_vars.push_back(var); // store all variables in fork scope into a vector
+				if (detect_union) fork_vars.push_back(var); // store all variables in fork scope into a vector
 				else registerVar(var); // otherwise, register the variable as normal
 				break;
 			}

--- a/kernel/fstdata.h
+++ b/kernel/fstdata.h
@@ -63,7 +63,6 @@ private:
 	void extractVarNames();
 	void registerVar(const FstVar &var);
 
-	bool fork_vars_had_nested_fork = false;  // Track if nested fork was detected
 	struct fstReaderContext *ctx;
 	std::vector<FstVar> vars;
 	std::map<fstHandle, FstVar> handle_to_var;

--- a/kernel/fstdata.h
+++ b/kernel/fstdata.h
@@ -61,6 +61,7 @@ class FstData
 	std::string autoScope(Module *topmod);
 private:
 	void extractVarNames();
+	void registerVar(const FstVar &var);
 
 	struct fstReaderContext *ctx;
 	std::vector<FstVar> vars;

--- a/kernel/fstdata.h
+++ b/kernel/fstdata.h
@@ -63,6 +63,7 @@ private:
 	void extractVarNames();
 	void registerVar(const FstVar &var);
 
+	bool fork_vars_had_nested_fork = false;  // Track if nested fork was detected
 	struct fstReaderContext *ctx;
 	std::vector<FstVar> vars;
 	std::map<fstHandle, FstVar> handle_to_var;


### PR DESCRIPTION
Support for union struct declared as $fork scopes.

1. Create helper function that populates data structure with variable name (useful for preventing duplicate logic)
2. Logic for union structs
  - when scoping, we track if we have entered a fork scope
  - if within a fork scope and we encounter a variable, we populate a vector with variables, otherwise, use helper to emit as normal
  - once we upscope, if we are coming from a fork scope, we check if it is a union (>= 2 vars all with same fstId). If it is a union, we treat the entire scope as a variable and emit it using helper
  - if it is not a fork scope, we loop through all variables in the vector and emit using helper function