### PR TITLE
[ENG-2090] Added annotate_ff_width pass + modifications for support in clockgate

### DIFF
--- a/passes/silimate/Makefile.inc
+++ b/passes/silimate/Makefile.inc
@@ -1,6 +1,7 @@
 
 OBJS += passes/silimate/activity.o
 OBJS += passes/silimate/annotate_cell_fanout.o
+OBJS += passes/silimate/annotate_ff_width.o
 OBJS += passes/silimate/breakreduce.o
 OBJS += passes/silimate/breaksop.o
 OBJS += passes/silimate/bus_rebuild.o

--- a/passes/silimate/annotate_ff_width.cc
+++ b/passes/silimate/annotate_ff_width.cc
@@ -42,9 +42,9 @@ struct AnnotateFfWidthPass : public Pass {
 
 		// Loop through all flip-flops and annotate with their width
 		int annotated = 0;
-		for (auto module : design->selected_modules()) {
-			for (auto cell : module->selected_cells()) {
-				if (!cell->is_builtin_ff())
+		for (auto module : design->modules()) {
+			for (auto cell : module->cells()) {
+				if (!RTLIL::builtin_ff_cell_types().count(cell->type))
 					continue;
 				int width;
 				if (cell->hasParam(ID::WIDTH))
@@ -57,7 +57,7 @@ struct AnnotateFfWidthPass : public Pass {
 				annotated++;
 			}
 		}
-		log("Annotated %d flip-flop / latch cells.\n", annotated);
+		log("Annotated %d flip-flops.\n", annotated);
 	}
 } AnnotateFfWidthPass;
 PRIVATE_NAMESPACE_END

--- a/passes/silimate/annotate_ff_width.cc
+++ b/passes/silimate/annotate_ff_width.cc
@@ -42,8 +42,8 @@ struct AnnotateFfWidthPass : public Pass {
 
 		// Loop through all flip-flops and annotate with their width
 		int annotated = 0;
-		for (auto module : design->modules()) {
-			for (auto cell : module->cells()) {
+		for (auto module : design->selected_modules()) {
+			for (auto cell : module->selected_cells()) {
 				if (!RTLIL::builtin_ff_cell_types().count(cell->type))
 					continue;
 				int width;

--- a/passes/silimate/annotate_ff_width.cc
+++ b/passes/silimate/annotate_ff_width.cc
@@ -1,0 +1,63 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2026  Stan Lee <stan@silimate.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct AnnotateFfWidthPass : public Pass {
+	AnnotateFfWidthPass() : Pass("annotate_ff_width", "annotate every flip-flop with its bit-width") { }
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    annotate_ff_width [selection]\n");
+		log("\n");
+		log("Annotate every flip-flop with its width.");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing ANNOTATE_FF_WIDTH pass.\n");
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+			break;
+		extra_args(args, argidx, design);
+
+		// Loop through all flip-flops and annotate with their width
+		int annotated = 0;
+		for (auto module : design->selected_modules()) {
+			for (auto cell : module->selected_cells()) {
+				if (!cell->is_builtin_ff())
+					continue;
+				int width;
+				if (cell->hasParam(ID::WIDTH))
+					width = cell->getParam(ID::WIDTH).as_int();
+				else if (cell->hasPort(ID::Q))
+					width = GetSize(cell->getPort(ID::Q));
+				else
+					width = 1;
+				cell->set_string_attribute(ID(ff_width), std::to_string(width));
+				annotated++;
+			}
+		}
+		log("Annotated %d flip-flop / latch cells.\n", annotated);
+	}
+} AnnotateFfWidthPass;
+PRIVATE_NAMESPACE_END

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -255,6 +255,8 @@ struct ClockgatePass : public Pass {
 		log("        Intended for DFT scan-enable pins.\n");
 		log("    -min_net_size <n>\n");
 		log("        Only transform sets of at least <n> eligible FFs.\n");
+		log("    -min_ff_size <n>\n");
+		log("        Only transform FFs whose original (pre-split) register width, or 'ff_width' attribute\n");
 		log("    -min_disabled_threshold <f>\n");
 		log("        Only transform sets of FFs where the total sum of disabled FFs is greater than <f>.\n");
 		log("    -max_src <n>\n");
@@ -323,6 +325,8 @@ struct ClockgatePass : public Pass {
 		std::vector<std::string> liberty_files;
 		std::vector<std::string> dont_use_cells;
 		int min_net_size = 0;
+		int min_ff_size = 0;
+		bool use_ff_size_threshold = false;
 		double min_disabled_threshold = -1;
 		bool use_disabled_threshold = false;
 		int max_src = -1;
@@ -355,6 +359,11 @@ struct ClockgatePass : public Pass {
 			}
 			if (args[argidx] == "-min_net_size" && argidx+1 < args.size()) {
 				min_net_size = atoi(args[++argidx].c_str());
+				continue;
+			}
+			if (args[argidx] == "-min_ff_size" && argidx+1 < args.size()) {
+				min_ff_size = atoi(args[++argidx].c_str());
+				use_ff_size_threshold = true;
 				continue;
 			}
 			if (args[argidx] == "-min_disabled_threshold" && argidx+1 < args.size()) {
@@ -411,6 +420,13 @@ struct ClockgatePass : public Pass {
 					if (!ff.sig_clk[0].is_wire() || !ff.sig_ce[0].is_wire())
 						continue;
 
+					if (use_ff_size_threshold) {
+						std::string attr = cell->get_string_attribute(ID(ff_width));
+						int orig_w = attr.empty() ? ff.width : atoi(attr.c_str());
+						if (orig_w < min_ff_size)
+							continue;
+					}
+
 					ce_ffs.insert(cell);
 
 					ClkNetInfo info = clk_info_from_ff(ff);
@@ -441,9 +457,13 @@ struct ClockgatePass : public Pass {
 				auto& gclk = clk_net.second;
 
 				// Check if the clock net qualifies for clock gating.
-				bool qualifies = use_disabled_threshold
-					? (gclk.en_disabled_sum >= min_disabled_threshold)
-					: (gclk.net_size >= min_net_size);
+				bool qualifies;
+				if (use_ff_size_threshold)
+					qualifies = (gclk.net_size >= 1);
+				else if (use_disabled_threshold)
+					qualifies = (gclk.en_disabled_sum >= min_disabled_threshold);
+				else
+					qualifies = (gclk.net_size >= min_net_size);
 				if (!qualifies)
 					continue;
 
@@ -563,7 +583,11 @@ struct ClockgatePass : public Pass {
 			clk_nets.clear();
 		}
 
-		log("Converted %d FFs using %s.\n", gated_flop_count, use_disabled_threshold ? "disabled threshold" : "net size");
+		const char *mode = use_ff_size_threshold   ? "FF width threshold"
+		                 : use_disabled_threshold  ? "disabled threshold"
+		                                           : "net size";
+
+		log("Converted %d FFs using %s.\n", gated_flop_count, mode);
     }
 } ClockgatePass;
 


### PR DESCRIPTION
Added "annotate_ff_width" pass
- loops over all flops in a design and annotates the flop with its width.
- ideally run before splitcells to get an idea of how large a flop was before splitting.

Modified clockgate pass to support gating on original flop width
- if a dffe has a original width greater than or equal to specified option, it will gate