### PR TITLE
[ENG-2238] -force-ram in verific frontend 

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3513,6 +3513,13 @@ struct VerificPass : public Pass {
 		log("Remove Verilog defines previously set with -vlog-define.\n");
 		log("\n");
 		log("\n");
+		log("    verific -force-ram <module>.<signal>..\n");
+		log("\n");
+		log("Treat each listed signal as if it had a (* force_ram *) attribute in the\n");
+		log("RTL, opting it into multi-port RAM extraction. Must be used before the\n");
+		log("Verilog sources are analyzed.\n");
+		log("\n");
+		log("\n");
 #endif
 		log("    verific -set-error <msg_id>..\n");
 		log("    verific -set-warning <msg_id>..\n");
@@ -3774,9 +3781,6 @@ struct VerificPass : public Pass {
 			RuntimeFlags::SetVar("veri_extract_dualport_rams", 0);
 			// RuntimeFlags::SetVar("veri_extract_multiport_rams", 1); // SILIMATE: control this externally
 			// RuntimeFlags::SetVar("veri_allow_any_ram_in_loop", 1);  // SILIMATE: control this externally
-			// SILIMATE: per-signal RAM extraction opt-in, comma-separated <module>.<signal> entries
-			RuntimeFlags::AddStringVar("veri_force_ram_signals", nullptr,
-					"Each matching signal behaves as if it had a (* force_ram *) attribute in the RTL.");
 			RuntimeFlags::SetVar("veri_replace_const_exprs", 1);
 #endif
 #ifdef VERIFIC_VHDL_SUPPORT
@@ -3924,6 +3928,13 @@ struct VerificPass : public Pass {
 				string name = args[argidx];
 				veri_file::UndefineMacro(name.c_str());
 			}
+			goto check_error;
+		}
+
+		// SILIMATE: register signals that behave as if annotated with (* force_ram *) in the RTL
+		if (GetSize(args) > argidx && args[argidx] == "-force-ram") {
+			for (argidx++; argidx < GetSize(args); argidx++)
+				veri_file::AddForceRamSignal(args[argidx].c_str());
 			goto check_error;
 		}
 

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -149,8 +149,11 @@ static void apply_force_ram_signals()
 			continue;
 		}
 		// Add force_ram attribute if not already present
-		if (!id->GetAttribute("force_ram"))
+		if (!id->GetAttribute("force_ram")) {
 			id->AddAttribute("force_ram", nullptr);
+			log("Added force_ram attribute to signal '%s' in module '%s'.\n",
+			         signal_name.c_str(), module_name.c_str());
+		}
 	}
 }
 

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -127,7 +127,7 @@ vector<string> verific_incdirs, verific_libdirs, verific_libexts;
 vector<string> verific_force_ram_signals;
 
 // SILIMATE: stamp the force_ram attribute onto the registered signals.
-static void apply_force_ram_signals()
+static void apply_force_ram_signals(const char *work)
 {
 	for (auto &entry : verific_force_ram_signals) {
 		// Validation
@@ -140,7 +140,11 @@ static void apply_force_ram_signals()
 		std::string module_name = entry.substr(0, dot);
 		std::string signal_name = entry.substr(dot + 1);
 		// Find module and signal from the design
-		VeriModule *veri_module = veri_file::GetModule(module_name.c_str());
+		VeriModule *veri_module = veri_file::GetModule(module_name.c_str(), 1, work);
+		if (!veri_module) {
+			log_warning("-force-ram: module '%s' not found.\n", module_name.c_str());
+			continue;
+		}
 		VeriScope *scope = veri_module ? veri_module->GetScope() : nullptr;
 		VeriIdDef *id = scope ? scope->FindLocal(signal_name.c_str()) : nullptr;
 		if (!id) {
@@ -3067,7 +3071,7 @@ void restore_blackbox_msg_state()
 void import_all(const char* work, std::map<std::string,Netlist*> *nl_todo, Map *parameters, bool show_message, std::string ppfile YS_MAYBE_UNUSED)
 {
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
-	apply_force_ram_signals(); // SILIMATE
+	apply_force_ram_signals(work); // SILIMATE
 #endif
 #ifdef YOSYSHQ_VERIFIC_EXTENSIONS
 	save_blackbox_msg_state();
@@ -3139,7 +3143,7 @@ std::set<std::string> import_tops(const char* work, std::map<std::string,Netlist
 	(void)top;
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
-	apply_force_ram_signals(); // SILIMATE
+	apply_force_ram_signals(work); // SILIMATE
 #endif
 
 #ifdef VERIFIC_VHDL_SUPPORT

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -58,6 +58,8 @@ USING_YOSYS_NAMESPACE
 #include "VeriWrite.h"
 #include "VeriLibrary.h"
 #include "VeriExpression.h"
+#include "VeriScope.h"
+#include "VeriId.h"
 #endif
 
 #ifdef VERIFIC_VHDL_SUPPORT
@@ -120,6 +122,37 @@ bool verific_no_split_complex_ports; // SILIMATE: disable splitting of complex p
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 vector<string> verific_incdirs, verific_libdirs, verific_libexts;
+
+// SILIMATE: "<module>.<signal>" entries to treat as if annotated with (* force_ram *)
+vector<string> verific_force_ram_signals;
+
+// SILIMATE: stamp the force_ram attribute onto the registered signals.
+static void apply_force_ram_signals()
+{
+	for (auto &entry : verific_force_ram_signals) {
+		// Validation
+		size_t dot = entry.find('.');
+		if (dot == std::string::npos || dot == 0 || dot + 1 == entry.size()) {
+			log_warning("-force-ram entry '%s' is not of the form <module>.<signal> required.\n", entry.c_str());
+			continue;
+		}
+		// Extract module and signal name
+		std::string module_name = entry.substr(0, dot);
+		std::string signal_name = entry.substr(dot + 1);
+		// Find module and signal from the design
+		VeriModule *veri_module = veri_file::GetModule(module_name.c_str());
+		VeriScope *scope = veri_module ? veri_module->GetScope() : nullptr;
+		VeriIdDef *id = scope ? scope->FindLocal(signal_name.c_str()) : nullptr;
+		if (!id) {
+			log_warning("-force-ram: signal '%s' not found in module '%s'.\n",
+			            signal_name.c_str(), module_name.c_str());
+			continue;
+		}
+		// Add force_ram attribute if not already present
+		if (!id->GetAttribute("force_ram"))
+			id->AddAttribute("force_ram", nullptr);
+	}
+}
 
 static void dump_verific_file_closure(const char *output_path, Array *file_names)
 {
@@ -3030,6 +3063,9 @@ void restore_blackbox_msg_state()
 
 void import_all(const char* work, std::map<std::string,Netlist*> *nl_todo, Map *parameters, bool show_message, std::string ppfile YS_MAYBE_UNUSED)
 {
+#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+	apply_force_ram_signals(); // SILIMATE
+#endif
 #ifdef YOSYSHQ_VERIFIC_EXTENSIONS
 	save_blackbox_msg_state();
 	VerificExtensions::ElaborateAndRewrite(work, parameters);
@@ -3098,6 +3134,10 @@ std::set<std::string> import_tops(const char* work, std::map<std::string,Netlist
 	std::set<std::string> top_mod_names;
 	Array *netlists = nullptr;
 	(void)top;
+
+#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+	apply_force_ram_signals(); // SILIMATE
+#endif
 
 #ifdef VERIFIC_VHDL_SUPPORT
 	VhdlLibrary *vhdl_lib = vhdl_file::GetLibrary(work, 1);
@@ -3282,6 +3322,7 @@ void verific_cleanup()
 	verific_incdirs.clear();
 	verific_libdirs.clear();
 	verific_libexts.clear();
+	verific_force_ram_signals.clear(); // SILIMATE
 #endif
 	verific_import_pending = false;
 }
@@ -3516,8 +3557,8 @@ struct VerificPass : public Pass {
 		log("    verific -force-ram <module>.<signal>..\n");
 		log("\n");
 		log("Treat each listed signal as if it had a (* force_ram *) attribute in the\n");
-		log("RTL, opting it into multi-port RAM extraction. Must be used before the\n");
-		log("Verilog sources are analyzed.\n");
+		log("RTL, opting it into multi-port RAM extraction. The attribute is applied\n");
+		log("when the design is elaborated (verific -import).\n");
 		log("\n");
 		log("\n");
 #endif
@@ -3934,7 +3975,7 @@ struct VerificPass : public Pass {
 		// SILIMATE: register signals that behave as if annotated with (* force_ram *) in the RTL
 		if (GetSize(args) > argidx && args[argidx] == "-force-ram") {
 			for (argidx++; argidx < GetSize(args); argidx++)
-				veri_file::AddForceRamSignal(args[argidx].c_str());
+				verific_force_ram_signals.push_back(args[argidx]);
 			goto check_error;
 		}
 

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3774,6 +3774,9 @@ struct VerificPass : public Pass {
 			RuntimeFlags::SetVar("veri_extract_dualport_rams", 0);
 			// RuntimeFlags::SetVar("veri_extract_multiport_rams", 1); // SILIMATE: control this externally
 			// RuntimeFlags::SetVar("veri_allow_any_ram_in_loop", 1);  // SILIMATE: control this externally
+			// SILIMATE: per-signal RAM extraction opt-in, comma-separated <module>.<signal> entries
+			RuntimeFlags::AddStringVar("veri_force_ram_signals", nullptr,
+					"Each matching signal behaves as if it had a (* force_ram *) attribute in the RTL.");
 			RuntimeFlags::SetVar("veri_replace_const_exprs", 1);
 #endif
 #ifdef VERIFIC_VHDL_SUPPORT


### PR DESCRIPTION
Adds functionality of adding force_ram attribute through verific frontend.

frontend populates a data structure of all the module.signal that should be 