### PR TITLE
Splitcells

### DIFF
--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -190,41 +190,43 @@ struct SplitcellsWorker
 					// Strip existing '[' or '.' from cell name
 					size_t bracket_pos = base_name.find_first_of("[.");
 					bool strip_reg = false;
+					std::string dim_index;
 					if (bracket_pos != std::string::npos) {
 
 						// Check if we will strip off _reg suffix from base name
 						size_t reg_pos = base_name.rfind("_reg");
-						if (reg_pos != std::string::npos && reg_pos > bracket_pos) {
+						if (reg_pos != std::string::npos && reg_pos > bracket_pos) { // <base>[word]_reg
+							dim_index = base_name.substr(bracket_pos, reg_pos - bracket_pos);
 							base_name = base_name.substr(0, reg_pos);
 							strip_reg = true;
+						} else { // <base>_reg[word]
+							dim_index = base_name.substr(bracket_pos);
 						}
 						base_name = base_name.substr(0, bracket_pos);
 					}
 
-					// Extract dimensional indices from Q port wire name
+					// Prefer dimensional index from the cell name; fall back to Q port wire name index otherwise
+					bool q_is_wire = slice_lsb < GetSize(raw_q) && raw_q[slice_lsb].is_wire();
+					if (dim_index.empty() && q_is_wire) {
+						std::string wire_name = raw_q[slice_lsb].wire->name.str();
+						size_t wb = wire_name.find_first_of("[.");
+						if (wb != std::string::npos)
+							dim_index = wire_name.substr(wb);
+					}
+
+					int bit_offset = q_is_wire ? user_index(slice_lsb) : name_lsb;
 					std::string wire_indices;
-					if (slice_lsb < GetSize(raw_q) && raw_q[slice_lsb].is_wire()) {
-
-							// Extract wire name (ex: \Memory[0] or \Memory.attr)
-							Wire *w = raw_q[slice_lsb].wire;
-							std::string wire_name = w->name.str();
-
-							// Extract bit offset from the wire (ex: 0)
-							int bit_offset = user_index(slice_lsb);
-
-							// Concatenate struct attribute or wire index (ex: \Memory[0] -> [0]) to the bit offset
-							size_t bracket_pos = wire_name.find_first_of("[.");
-							if (bracket_pos != std::string::npos) {
-									wire_indices = wire_name.substr(bracket_pos) + (strip_reg ? "_reg" : "") + stringf(
-										"%c%d%c", format[0], bit_offset, format[1]);
-							} else { // no '[' or '.', so no concatenation using wire, use slice_lsb + name_lsb offset instead
-									wire_indices = stringf(
-										"%c%d%c", format[0], slice_lsb + user_index(0), format[1]);
-							}
+					if (!dim_index.empty()) {
+						// Concatenate struct attribute or wire index (ex: \Memory[0] -> [0]) to the bit offset
+						wire_indices = dim_index + (strip_reg ? "_reg" : "") + stringf(
+							"%c%d%c", format[0], bit_offset, format[1]);
 					} else {
-							// Fallback
-							wire_indices = stringf(
-								"%c%d%c", format[0], name_lsb, format[1]);
+						// no '[' or '.' on cell or Q, warn as this may cause problems in reg annotation
+						wire_indices = stringf("%c%d%c", format[0],
+							q_is_wire ? slice_lsb + user_index(0) : name_lsb, format[1]);
+						if (i == 1)
+							log_warning("Unexpected FF name %s.%s while blasting; no [.] index on cell or Q port\n",
+								log_id(module), log_id(cell));
 					}
 					// Construct uniquified name by concatenating the base name with the wire indices
 					slice_name = module->uniquify(base_name + wire_indices);

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -199,7 +199,7 @@ struct SplitcellsWorker
 							dim_index = base_name.substr(bracket_pos, reg_pos - bracket_pos);
 							base_name = base_name.substr(0, reg_pos);
 							strip_reg = true;
-						} else { // <base>_reg[word]
+						} else { // <base>_reg[word] / <base>_reg.attr, or <base>[word] with no _reg
 							dim_index = base_name.substr(bracket_pos);
 						}
 						base_name = base_name.substr(0, bracket_pos);

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -96,9 +96,10 @@ struct RegRenameInstance {
 			// Walk right-to-left, removing each trailing "[digits]" group.
 			while (end && cellName[end - 1] == ']') {
 				size_t open = cellName.rfind('[', end - 1);
-				std::string inner = cellName.substr(open + 1, end - open - 2); // chars between [ ] brackets
-				if (open == std::string::npos || inner.empty() ||
-						inner.find_first_not_of("0123456789") != std::string::npos)
+				if (open == std::string::npos)
+					break;
+				std::string inner = cellName.substr(open + 1, end - open - 2);
+				if (inner.empty() || inner.find_first_not_of("0123456789") != std::string::npos)
 					break;
 				end = open;
 			}

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -106,9 +106,8 @@ struct RegRenameInstance {
 
 			// After peeling, the name is a register if the base ends in "_reg".
 			bool is_reg = end >= 4 && cellName.compare(end - 4, 4, "_reg") == 0;
-			size_t reg_pos = end - 4; // position of "_reg"
-
 			if (is_reg) {
+				size_t reg_pos = end - 4; // position of "_reg"
 
 				// Remove "_reg" to get the target wire specification
 				cellName.erase(reg_pos, 4);

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -89,17 +89,27 @@ struct RegRenameInstance {
 				continue;
 			}
 
-			// We know it is a reg with _reg suffix with all brackets removed
-			std::string searchName = cell->name.c_str();
-			if (auto pos = searchName.find('['); pos != std::string::npos)
-				searchName.erase(pos);
+			// Accept both \name_reg[bit] and \name[word]_reg[bit].
+			std::string cellName = cell->name.c_str();
+			size_t end = cellName.size();
 
-			// If register name with no brackets ends with _reg, we can process it
-			size_t reg_pos = searchName.rfind("_reg");
-			if (reg_pos != std::string::npos && reg_pos == searchName.size() - 4) {
+			// Walk right-to-left, removing each trailing "[digits]" group.
+			while (end && cellName[end - 1] == ']') {
+				size_t open = cellName.rfind('[', end - 1);
+				std::string inner = cellName.substr(open + 1, end - open - 2); // chars between [ ] brackets
+				if (open == std::string::npos || inner.empty() ||
+						inner.find_first_not_of("0123456789") != std::string::npos)
+					break;
+				end = open;
+			}
+
+			// After peeling, the name is a register if the base ends in "_reg".
+			bool is_reg = end >= 4 && cellName.compare(end - 4, 4, "_reg") == 0;
+			size_t reg_pos = end - 4; // position of "_reg"
+
+			if (is_reg) {
 
 				// Remove "_reg" to get the target wire specification
-				std::string cellName = cell->name.c_str();
 				cellName.erase(reg_pos, 4);
 
 				// Index comes from the right-most brackets


### PR DESCRIPTION
Summary
1. splitcells -blast: Prefer the dimensional index ([word] / .attr) from the FF cell name when building blasted names; only fall back to the Q wire if the cell has none. Avoids bad names when Q is renamed/const and keeps forms like \mem[0]_reg[bit].
2. Warn once per cell when neither the cell name nor Q carries a [.] index (bit-only fallback).
3. reg_rename: Recognize both \name_reg[bit] and \name[word]_reg[bit] by peeling trailing [digits] groups and checking the base ends in _reg, so registers emitted by the new splitcells naming are no longer skipped.