### PR TITLE
[ENG-2304] reg-rename alias fix

### DIFF
--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -227,6 +227,32 @@ struct RegRenameInstance {
 
 		// Delete the old unused wires
 		module->remove(wireRemoveCache);
+
+		// Drop leftover alias/X assigns onto claimed bits.
+		if (!claimed_bits.empty()) {
+			std::vector<RTLIL::SigSig> kept;
+			bool dropped = false;
+			// Rebuild connection list, omitting bits that flops now own.
+			for (auto &conn : module->connections()) {
+				RTLIL::SigSpec new_lhs, new_rhs;
+				for (int i = 0; i < GetSize(conn.first); i++) {
+					SigBit lb = conn.first[i];
+					// Alias/opt left an assign (often to X) on the restored Q bit.
+					if (lb.wire && claimed_bits.count(lb)) {
+						dropped = true;
+						continue;
+					}
+					new_lhs.append(lb);
+					new_rhs.append(conn.second[i]);
+				}
+				// Keep any remaining (non-claimed) slice of this assign.
+				if (GetSize(new_lhs))
+					kept.push_back(RTLIL::SigSig(new_lhs, new_rhs));
+			}
+			// Only rewrite the module if we actually removed something.
+			if (dropped)
+				module->new_connections(kept);
+		}
 	}
 
 	void process_all(dict<std::string, RegInfo> &vcd_reg_widths)

--- a/passes/silimate/reg_rename.cc
+++ b/passes/silimate/reg_rename.cc
@@ -231,26 +231,25 @@ struct RegRenameInstance {
 		// Drop leftover alias/X assigns onto claimed bits.
 		if (!claimed_bits.empty()) {
 			std::vector<RTLIL::SigSig> kept;
-			bool dropped = false;
+			bool changed = false;
 			// Rebuild connection list, omitting bits that flops now own.
 			for (auto &conn : module->connections()) {
-				RTLIL::SigSpec new_lhs, new_rhs;
+				RTLIL::SigSpec lhs, rhs; // lhs = driven, rhs = driver
 				for (int i = 0; i < GetSize(conn.first); i++) {
-					SigBit lb = conn.first[i];
 					// Alias/opt left an assign (often to X) on the restored Q bit.
-					if (lb.wire && claimed_bits.count(lb)) {
-						dropped = true;
+					if (claimed_bits.count(conn.first[i])) {
+						changed = true;
 						continue;
 					}
-					new_lhs.append(lb);
-					new_rhs.append(conn.second[i]);
+					lhs.append(conn.first[i]);
+					rhs.append(conn.second[i]);
 				}
 				// Keep any remaining (non-claimed) slice of this assign.
-				if (GetSize(new_lhs))
-					kept.push_back(RTLIL::SigSig(new_lhs, new_rhs));
+				if (GetSize(lhs))
+					kept.emplace_back(lhs, rhs);
 			}
 			// Only rewrite the module if we actually removed something.
-			if (dropped)
+			if (changed)
 				module->new_connections(kept);
 		}
 	}


### PR DESCRIPTION
After rename, each bit in claimed_bits is driven by a flop. This pass removes any leftover module connects that still drive those same bits, which leads to a SIM pass hang.

Algorithm:
1. Skip if nothing claimed — no restored flop bits, nothing to clean.
2. Walk every module connection — each conn is an assign: lhs = rhs (bit-parallel).
3. Per bit — if conn.first[i] (driven bit) is in claimed_bits, drop that bit pair (that’s the leftover alias/X assign). Otherwise keep it in lhs/rhs.
4. Keep partial assigns — if an assign still has unclaimed bits, push the trimmed lhs/rhs into kept.
5. Commit only if needed — if anything was dropped, replace the module’s connection list with kept.

Net effect: flop is the only driver of each claimed bit; competing connects are gone.