### PR TITLE
[ENG-2288] More opt_boundary speed improvements

### DIFF
--- a/passes/silimate/opt_boundary.cc
+++ b/passes/silimate/opt_boundary.cc
@@ -25,13 +25,38 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
+// Child-only cone data that is independent of the parent instance, so it can be
+// built once per child module and reused across all of its instances.
+struct ChildConeInfo {
+	SigMap sigmap;
+	dict<SigBit, Cell*> bit_driver; // canonical child bit -> cell that drives it
+
+	ChildConeInfo() {}
+
+	ChildConeInfo(Module *child) : sigmap(child)
+	{
+		for (auto cell : child->cells()) {
+			// Only evaluable, non-kept cells can be safely copied into the parent.
+			if (!yosys_celltypes.cell_evaluable(cell->type) || cell->has_keep_attr())
+				continue;
+			for (auto &conn : cell->connections()) {
+				if (!yosys_celltypes.cell_output(cell->type, conn.first))
+					continue;
+				// Map each driven bit to its driver.
+				for (auto bit : conn.second)
+					if (bit.is_wire())
+						bit_driver[sigmap(bit)] = cell;
+			}
+		}
+	}
+};
+
 struct BoundaryConeWorker {
 	Module *child, *parent;
-	SigMap child_sigmap;
+	const ChildConeInfo &info;
 	int max_cells;
 	int max_bits;
 
-	dict<SigBit, Cell*> bit_driver;
 	dict<SigBit, SigBit> input_map;
 	dict<SigBit, SigBit> copied_bits;
 	dict<Cell*, Cell*> copied_cells;
@@ -43,8 +68,8 @@ struct BoundaryConeWorker {
 	bool setup_failed = false;
 	bool failed = false;
 
-	BoundaryConeWorker(Module *child, Module *parent, Cell *instance, int max_cells, int max_bits)
-		: child(child), parent(parent), child_sigmap(child), max_cells(max_cells), max_bits(max_bits)
+	BoundaryConeWorker(Module *child, Module *parent, Cell *instance, const ChildConeInfo &info, int max_cells, int max_bits)
+		: child(child), parent(parent), info(info), max_cells(max_cells), max_bits(max_bits)
 	{
 		for (auto wire : child->wires()) {
 			if (!wire->port_input || wire->port_output)
@@ -57,25 +82,13 @@ struct BoundaryConeWorker {
 				continue;
 			}
 			for (int i = 0; i < wire->width; i++)
-				input_map[child_sigmap(SigBit(wire, i))] = conn[i];
-		}
-
-		for (auto cell : child->cells()) {
-			if (!yosys_celltypes.cell_evaluable(cell->type) || cell->has_keep_attr())
-				continue;
-			for (auto &conn : cell->connections()) {
-				if (!yosys_celltypes.cell_output(cell->type, conn.first))
-					continue;
-				for (auto bit : conn.second)
-					if (bit.is_wire())
-						bit_driver[child_sigmap(bit)] = cell;
-			}
+				input_map[info.sigmap(SigBit(wire, i))] = conn[i];
 		}
 
 		failed = setup_failed;
 	}
 
-	// Drop per-attempt copy state but keep bit_driver/input_map for reuse across bits.
+	// Drop per-attempt copy state but keep input_map (and the shared child info) for reuse across bits.
 	void clear_copy_state()
 	{
 		created_cells.clear();
@@ -105,7 +118,7 @@ struct BoundaryConeWorker {
 
 	SigBit materialize(SigBit bit)
 	{
-		bit = child_sigmap(bit);
+		bit = info.sigmap(bit);
 
 		if (!bit.is_wire())
 			return bit;
@@ -116,12 +129,12 @@ struct BoundaryConeWorker {
 		if (copied_bits.count(bit))
 			return copied_bits.at(bit);
 
-		if (!bit_driver.count(bit)) {
+		if (!info.bit_driver.count(bit)) {
 			failed = true;
 			return RTLIL::Sx;
 		}
 
-		Cell *driver = bit_driver.at(bit);
+		Cell *driver = info.bit_driver.at(bit);
 		if (active_cells.count(driver) || copied_cell_count >= max_cells) {
 			failed = true;
 			return RTLIL::Sx;
@@ -159,7 +172,7 @@ struct BoundaryConeWorker {
 				new_connections[conn.first] = mapped;
 				for (int i = 0; i < GetSize(conn.second); i++) {
 					if (conn.second[i].is_wire())
-						copied_bits[child_sigmap(conn.second[i])] = mapped[i];
+						copied_bits[info.sigmap(conn.second[i])] = mapped[i];
 				}
 				continue;
 			}
@@ -187,8 +200,9 @@ struct BoundaryConeWorker {
 	{
 		for (auto it = created_cells.rbegin(); it != created_cells.rend(); ++it)
 			parent->remove(*it);
-		for (auto it = created_wires.rbegin(); it != created_wires.rend(); ++it)
-			parent->remove(pool<Wire*>{*it});
+		// Batch wire removal to avoid bit-level blowup.
+		if (!created_wires.empty())
+			parent->remove(pool<Wire*>(created_wires.begin(), created_wires.end()));
 		clear_copy_state();
 	}
 };
@@ -307,6 +321,9 @@ struct OptBoundaryPass : Pass {
 			log_cmd_error("The -max_bits value must be positive.\n");
 
 		bool did_something = false;
+		// bit_driver/sigmap depend only on the child module, so cache them across
+		// all instances (and parents) instead of rebuilding per instance.
+		dict<Module*, ChildConeInfo> child_info_cache;
 		for (auto parent : design->selected_modules(RTLIL::SELECT_WHOLE_ONLY, RTLIL::SB_UNBOXED_CMDERR)) {
 			if (protected_module(parent)) {
 				log_debug("opt_boundary: skipping protected parent module %s\n", log_id(parent));
@@ -333,8 +350,11 @@ struct OptBoundaryPass : Pass {
 					continue;
 				}
 
-				// Build bit_driver/input_map once per instance; reset only copy state between bits.
-				BoundaryConeWorker worker(child, parent, instance, max_cells, max_bits);
+				// bit_driver/sigmap are reused from the child cache; only the
+				// instance-specific input_map is built per instance here.
+				if (!child_info_cache.count(child))
+					child_info_cache[child] = ChildConeInfo(child);
+				BoundaryConeWorker worker(child, parent, instance, child_info_cache.at(child), max_cells, max_bits);
 
 				for (auto &conn : instance->connections_) {
 					Wire *port = child->wire(conn.first);

--- a/passes/silimate/opt_boundary.cc
+++ b/passes/silimate/opt_boundary.cc
@@ -63,13 +63,15 @@ struct BoundaryConeWorker {
 	std::vector<Wire*> created_wires;
 	std::vector<Cell*> created_cells;
 	pool<Cell*> active_cells;
+	std::vector<Wire*> &dead_wires; // parent-scope stash of rolled-back wires, removed in one batch
 	int copied_cell_count = 0;
 	int materialized_bit_count = 0;
 	bool setup_failed = false;
 	bool failed = false;
 
-	BoundaryConeWorker(Module *child, Module *parent, Cell *instance, const ChildConeInfo &info, int max_cells, int max_bits)
-		: child(child), parent(parent), info(info), max_cells(max_cells), max_bits(max_bits)
+	BoundaryConeWorker(Module *child, Module *parent, Cell *instance, const ChildConeInfo &info,
+			std::vector<Wire*> &dead_wires, int max_cells, int max_bits)
+		: child(child), parent(parent), info(info), max_cells(max_cells), max_bits(max_bits), dead_wires(dead_wires)
 	{
 		for (auto wire : child->wires()) {
 			if (!wire->port_input || wire->port_output)
@@ -200,9 +202,7 @@ struct BoundaryConeWorker {
 	{
 		for (auto it = created_cells.rbegin(); it != created_cells.rend(); ++it)
 			parent->remove(*it);
-		// Batch wire removal to avoid bit-level blowup.
-		if (!created_wires.empty())
-			parent->remove(pool<Wire*>(created_wires.begin(), created_wires.end()));
+		dead_wires.insert(dead_wires.end(), created_wires.begin(), created_wires.end());
 		clear_copy_state();
 	}
 };
@@ -332,6 +332,9 @@ struct OptBoundaryPass : Pass {
 
 			ParentUsage parent_usage(parent, design);
 
+			// Wires from rolled-back cones are collected here and removed in one batch below.
+			std::vector<Wire*> dead_wires;
+
 			for (auto instance : parent->cells().to_vector()) {
 				if (instance->has_keep_attr()) {
 					log_debug("opt_boundary: skipping kept instance %s in %s\n", log_id(instance), log_id(parent));
@@ -354,7 +357,7 @@ struct OptBoundaryPass : Pass {
 				// instance-specific input_map is built per instance here.
 				if (!child_info_cache.count(child))
 					child_info_cache[child] = ChildConeInfo(child);
-				BoundaryConeWorker worker(child, parent, instance, child_info_cache.at(child), max_cells, max_bits);
+				BoundaryConeWorker worker(child, parent, instance, child_info_cache.at(child), dead_wires, max_cells, max_bits);
 
 				for (auto &conn : instance->connections_) {
 					Wire *port = child->wire(conn.first);
@@ -428,6 +431,10 @@ struct OptBoundaryPass : Pass {
 						conn.second = new_conn;
 				}
 			}
+
+			// Single whole-module scan to drop all rolled-back wires for this parent.
+			if (!dead_wires.empty())
+				parent->remove(pool<Wire*>(dead_wires.begin(), dead_wires.end()));
 		}
 
 		if (did_something)

--- a/passes/silimate/opt_boundary.cc
+++ b/passes/silimate/opt_boundary.cc
@@ -335,6 +335,9 @@ struct OptBoundaryPass : Pass {
 			// Wires from rolled-back cones are collected here and removed in one batch below.
 			std::vector<Wire*> dead_wires;
 
+			// Tracks whether the parent module was mutated.
+			bool parent_changed = false;
+
 			for (auto instance : parent->cells().to_vector()) {
 				if (instance->has_keep_attr()) {
 					log_debug("opt_boundary: skipping kept instance %s in %s\n", log_id(instance), log_id(parent));
@@ -417,6 +420,7 @@ struct OptBoundaryPass : Pass {
 							changed_port = true;
 						}
 						did_something = true;
+						parent_changed = true;
 
 						if (copied_cells > 0)
 							log("Copied %d cells from cone driving %s[%d] of instance '%s' (type '%s') into '%s'\n",
@@ -435,6 +439,10 @@ struct OptBoundaryPass : Pass {
 			// Single whole-module scan to drop all rolled-back wires for this parent.
 			if (!dead_wires.empty())
 				parent->remove(pool<Wire*>(dead_wires.begin(), dead_wires.end()));
+
+			// Invalidate child info cache if we mutated this parent.
+			if (parent_changed)
+				child_info_cache.erase(parent);
 		}
 
 		if (did_something)

--- a/tests/silimate/opt_boundary.ys
+++ b/tests/silimate/opt_boundary.ys
@@ -931,3 +931,183 @@ select -assert-count 1 top/t:m
 
 design -reset
 log -pop
+
+log -header "Overlapping cones: instances share parent inputs"
+log -push
+design -reset
+# u0 and u1 both read a,b, so their copied cones overlap on the same parent inputs.
+# Expect: both leaf boundaries gone, one $and per instance (2 total, unique names).
+read_verilog <<EOF
+module leaf(input a, input b, output y);
+  assign y = a & b;
+endmodule
+
+module top(input a, input b, output y0, output y1);
+  leaf u0(.a(a), .b(b), .y(y0));
+  leaf u1(.a(a), .b(b), .y(y1));
+endmodule
+EOF
+hierarchy -top top
+proc
+opt_expr
+opt_clean
+design -save start
+flatten
+design -save gold
+design -load start
+opt_boundary
+opt_clean
+select -assert-count 0 top/t:leaf
+select -assert-count 2 top/t:$and
+flatten
+design -save gate
+
+design -reset
+design -copy-from gold -as gold A:top
+design -copy-from gate -as gate A:top
+rename -hide
+equiv_make gold gate equiv
+equiv_simple equiv
+equiv_status -assert equiv
+
+design -reset
+log -pop
+
+log -header "Overlapping cones: chained instances"
+log -push
+design -reset
+# u1 consumes u0's output t, so the two copied cones overlap/chain through net t.
+# Expect: both leaf boundaries gone, 2 $and copied and wired in series.
+read_verilog <<EOF
+module leaf(input a, input b, output y);
+  assign y = a & b;
+endmodule
+
+module top(input a, input b, input c, output y);
+  wire t;
+  leaf u0(.a(a), .b(b), .y(t));
+  leaf u1(.a(t), .b(c), .y(y));
+endmodule
+EOF
+hierarchy -top top
+proc
+opt_expr
+opt_clean
+design -save start
+flatten
+design -save gold
+design -load start
+opt_boundary
+opt_clean
+select -assert-count 0 top/t:leaf
+select -assert-count 2 top/t:$and
+flatten
+design -save gate
+
+design -reset
+design -copy-from gold -as gold A:top
+design -copy-from gate -as gate A:top
+rename -hide
+equiv_make gold gate equiv
+equiv_simple equiv
+equiv_status -assert equiv
+
+design -reset
+log -pop
+
+log -header "Overlapping cones: shared sub-cone within one instance"
+log -push
+design -reset
+# x and y both use t=a&b, so their cones overlap on t; each output copies its own cone,
+# so t is duplicated rather than shared. Expect: 0 leaf, 2 $and (dup), 1 $xor, 1 $or.
+read_verilog <<EOF
+module leaf(input a, input b, input c, output x, output y);
+  wire t = a & b;
+  assign x = t ^ c;
+  assign y = t | c;
+endmodule
+
+module top(input a, input b, input c, output x, output y);
+  leaf u(.a(a), .b(b), .c(c), .x(x), .y(y));
+endmodule
+EOF
+hierarchy -top top
+proc
+opt_expr
+opt_clean
+design -save start
+flatten
+design -save gold
+design -load start
+opt_boundary
+opt_clean
+select -assert-count 0 top/t:leaf
+select -assert-count 2 top/t:$and
+select -assert-count 1 top/t:$xor
+select -assert-count 1 top/t:$or
+flatten
+design -save gate
+
+design -reset
+design -copy-from gold -as gold A:top
+design -copy-from gate -as gate A:top
+rename -hide
+equiv_make gold gate equiv
+equiv_simple equiv
+equiv_status -assert equiv
+
+design -reset
+log -pop
+
+log -header "Modified module is reoptimized as a child (cache invalidation)"
+log -push
+design -reset
+# q_mid gets l_leaf's cone in one pass, which makes q_mid itself optimizable as a child.
+# A parent visited after that (p_pre) bubbles q_mid up too -- only if q_mid's stale
+# child-cone cache is invalidated. Expect: p_pre optimized (0 q_mid, 1 $and); r_post,
+# visited before q_mid changed, keeps its q_mid instance.
+read_verilog <<EOF
+module p_pre(input a, input b, output y);
+  q_mid u(.a(a), .b(b), .y(y));
+endmodule
+
+module q_mid(input a, input b, output y);
+  l_leaf u(.a(a), .b(b), .y(y));
+endmodule
+
+module r_post(input a, input b, output y);
+  q_mid u(.a(a), .b(b), .y(y));
+endmodule
+
+module l_leaf(input a, input b, output y);
+  assign y = a & b;
+endmodule
+EOF
+proc
+opt_expr
+opt_clean
+design -save start
+flatten
+design -save gold
+design -load start
+opt_boundary
+opt_clean
+
+select -assert-count 1 r_post/t:q_mid
+select -assert-count 0 r_post/t:$and
+
+select -assert-count 0 p_pre/t:q_mid
+select -assert-count 1 p_pre/t:$and
+flatten
+design -save gate
+
+design -reset
+design -copy-from gold -as gold p_pre
+design -copy-from gate -as gate p_pre
+rename -hide
+equiv_make gold gate equiv
+equiv_simple equiv
+equiv_status -assert equiv
+
+design -reset
+log -pop


### PR DESCRIPTION
Speed up opt_boundary without changing netlist behavior by removing two algorithmic bottlenecks:

Cache child cone data per module. bit_driver/sigmap depend only on the child, but were rebuilt for every instance. Hoist them into ChildConeInfo and reuse across instances/parents; workers still build only the per-instance input_map.

Defer rolled-back wire deletion. Module::remove(pool<Wire*>) scans the whole parent. Rollback used to do that once per rejected bit (and previously per wire). Now rollback removes cells immediately and stashes orphaned wires; each parent flushes them in one batched remove at the end.

On the largest design I could find, runtime went from 18 sec to <1sec.