### PR TITLE
opt_modadd_tree: keep the transfer-function shape off one-bit states

### DIFF
--- a/passes/opt/opt_modadd_tree.cc
+++ b/passes/opt/opt_modadd_tree.cc
@@ -64,6 +64,7 @@ struct OptModAddTreeWorker : CutRegionWorker
 {
 	// Tunables (see Pass::execute).
 	int max_state_bits = 4;
+	int min_state_bits = 2;
 	int min_nodes = 4;
 	int max_nodes = 64;
 	int max_cone_cells = 512;
@@ -818,6 +819,16 @@ struct OptModAddTreeWorker : CutRegionWorker
 					cb.table.append(const_u64(v, ch.w));
 		}
 
+		// The transfer-function tier copies the step cone once per state, which
+		// only pays off when the state is too wide to rebalance associatively.
+		// A 1-bit accumulator is a boolean chain that tree balancing flattens
+		// for free, so cloning its cone just buys area.
+		if (!as_table && ch.w < min_state_bits) {
+			log_debug("  skipping general cascade at %s: state width %d below %d\n",
+			          log_signal(ch.tail), ch.w, min_state_bits);
+			return false;
+		}
+
 		int clones = 0;
 		for (int i = 1; i < n; i++)
 			clones += GetSize(ch.state_cells[i]) * (as_table ? 1 : nstates);
@@ -952,6 +963,11 @@ struct OptModAddTreePass : public Pass {
 		log("    -max-state-bits N, -max_state_bits N\n");
 		log("        maximum accumulator width to consider (default 4).\n");
 		log("\n");
+		log("    -min-state-bits N, -min_state_bits N\n");
+		log("        minimum accumulator width for the general shape (default 2).\n");
+		log("        Narrower states are boolean chains that tree balancing\n");
+		log("        already flattens, so cloning their step cones only costs area.\n");
+		log("\n");
 		log("    -min-nodes N, -min_nodes N\n");
 		log("        minimum cascade length to rebalance (default 4).\n");
 		log("\n");
@@ -986,6 +1002,7 @@ struct OptModAddTreePass : public Pass {
 		log_header(design, "Executing OPT_MODADD_TREE pass (serial accumulate cascades to trees).\n");
 
 		int max_state_bits = 4;
+		int min_state_bits = 2;
 		int min_nodes = 4;
 		int max_nodes = 64;
 		int max_digit_bits = 10;
@@ -998,6 +1015,11 @@ struct OptModAddTreePass : public Pass {
 			if ((args[argidx] == "-max-state-bits" || args[argidx] == "-max_state_bits") &&
 			    argidx + 1 < args.size()) {
 				max_state_bits = std::stoi(args[++argidx]);
+				continue;
+			}
+			if ((args[argidx] == "-min-state-bits" || args[argidx] == "-min_state_bits") &&
+			    argidx + 1 < args.size()) {
+				min_state_bits = std::stoi(args[++argidx]);
 				continue;
 			}
 			if ((args[argidx] == "-min-nodes" || args[argidx] == "-min_nodes") &&
@@ -1053,6 +1075,7 @@ struct OptModAddTreePass : public Pass {
 		for (auto module : design->selected_modules()) {
 			OptModAddTreeWorker worker(module);
 			worker.max_state_bits = max_state_bits;
+			worker.min_state_bits = min_state_bits;
 			worker.min_nodes = min_nodes;
 			worker.max_nodes = max_nodes;
 			worker.max_digit_bits = max_digit_bits;

--- a/tests/opt/opt_modadd_tree.ys
+++ b/tests/opt/opt_modadd_tree.ys
@@ -6,6 +6,7 @@
 #   C: transfer-function tree (emit shape 2) on a step that is NOT associative.
 #   D: rejection guards -- wrong fixup constant, state too wide, clone budget.
 #   E: the depth-win guard, which keeps the shape off shallow cascades.
+#   F: the narrow-state guard, which keeps the shape off boolean chains.
 #
 # Depth is the point of this pass, so the structural checks are `ltp -noff`
 # lengths rather than cell counts: the tree trades area for depth, so cell
@@ -402,6 +403,99 @@ design -load shallow
 logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 1 cascade\(s\) as transfer-function tree\(s\)" 1
 opt_modadd_tree -min-serial-depth 8 -min-depth-gain 1
 logger -check-expected
+select -assert-min 1 c:*modadd*
+design -reset
+log -pop
+
+# ============================================================================
+# Group F: narrow-state guard
+# ============================================================================
+
+# F1: a flag threaded through eight compare steps. The state is one bit, so
+# the transfer-function shape would clone each compare cone twice to carry a
+# map that tree balancing gets for free -- on a real FPU this shape cost 17x
+# area for no depth. Deep enough that only the width guard can refuse it.
+log -header "F1: one-bit state -> left alone"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [127:0] a, input wire [15:0] k, output wire y);
+  function automatic f (input [127:0] v, input [15:0] kk);
+    integer i; reg acc; reg [15:0] t;
+    begin
+      acc = 1'b0;
+      for (i = 0; i < 8; i = i + 1) begin
+        t = v[i*16 +: 16] + kk;
+        if (t > kk)
+          acc = ~acc;
+        else
+          acc = acc & t[0];
+      end
+      f = acc;
+    end
+  endfunction
+  assign y = f(a, k);
+endmodule
+EOF
+proc
+opt_expr
+opt_clean
+check -assert
+design -save flag
+# Every prefix of the chain is its own candidate, so pin the full-length one
+# rather than counting all sixteen skips.
+logger -expect log "skipping general cascade at .y: state width 1 below 2" 1
+logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 0 cascade\(s\) as transfer-function tree\(s\)" 1
+debug opt_modadd_tree
+logger -check-expected
+select -assert-count 0 c:*modadd*
+log -pop
+
+# F2: the same cascade rewrites at -min-state-bits 1, so F1 is the width guard
+# declining a match the pass otherwise takes.
+log -header "F2: one-bit state rewrites once the width guard allows it"
+log -push
+design -load flag
+logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 1 cascade\(s\) as transfer-function tree\(s\)" 1
+opt_modadd_tree -min-state-bits 1
+logger -check-expected
+select -assert-min 1 c:*modadd*
+design -reset
+log -pop
+
+# F3: the width guard is a cost call, not a correctness one, so prove the
+# rewrite it declines. Same flag chain narrowed to 4-bit steps, which keeps the
+# equivalence check cheap; the thresholds come down to match the shorter chain.
+log -header "F3: the declined one-bit rewrite is equivalent"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [23:0] a, input wire [3:0] k, output wire y);
+  function automatic f (input [23:0] v, input [3:0] kk);
+    integer i; reg acc; reg [3:0] t;
+    begin
+      acc = 1'b0;
+      for (i = 0; i < 6; i = i + 1) begin
+        t = v[i*4 +: 4] + kk;
+        if (t > kk)
+          acc = ~acc;
+        else
+          acc = acc & t[0];
+      end
+      f = acc;
+    end
+  endfunction
+  assign y = f(a, k);
+endmodule
+EOF
+proc
+opt_expr
+opt_clean
+check -assert
+logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 1 cascade\(s\) as transfer-function tree\(s\)" 1
+equiv_opt -assert opt_modadd_tree -min-state-bits 1 -min-serial-depth 8 -min-depth-gain 1
+logger -check-expected
+design -load postopt
 select -assert-min 1 c:*modadd*
 design -reset
 log -pop


### PR DESCRIPTION
Found while integrating the four pattern passes on the Preqorsor side (Silimate/preqorsor#2127): with `opt_modadd_tree` in the default flow, the `fpu` benchmark went from 1272 to 21656 area while depth stayed flat at 1256.

## What happened

The pass matched 15 cascades on fpu whose accumulator is a single flag -- `overflow`, `underflow`, `ine_fasu`, `underflow_fdiv` and similar. Each was taken by the transfer-function tier, which clones the step cone once per state to carry a state->state map:

```
general cascade at \overflow:  4 node(s), state width 1, 320 clone(s), serial depth 37 -> tree depth 7
general cascade at \underflow: 4 node(s), state width 1, 350 clone(s), serial depth 45 -> tree depth 7
```

Two things went wrong together. The clone budget counts step *cells*, not what they cost, so 320 copies of an FPU compare cone sit comfortably under the 1024 default. And the depth model is local: those flags sit at depth 37-45 inside a design whose critical path is 1256, so the "win" it priced was never going to show up.

## The guard

A one-bit accumulate is a boolean chain, and tree balancing already flattens those without replicating anything, so the transfer-function shape now requires `-min-state-bits` (default 2). Scope is deliberately narrow:

- The associative shape is untouched. It clones once per node regardless of state width, so a narrow state costs it nothing.
- The mod-7 and mod-9 cascades this pass was written for carry 3 and 4 bits and still rewrite.

With the guard, fpu matches main exactly again: lol 1256.5, clk 26030, area 1272.5.

## Tests

New group F in `tests/opt/opt_modadd_tree.ys`: a flag chain deep enough that only the width check can refuse it (F1), the same chain rewriting at `-min-state-bits 1` so F1 is the guard declining a real match (F2), and a narrowed copy proving that declined rewrite equivalent, since the guard is a cost call rather than a correctness one (F3).

`tests/opt` and `tests/silimate`: 130 passed, 0 failed.

Made with [Cursor](https://cursor.com)