### PR TITLE
muxpush: only push where it can shorten the longest path

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -222,13 +222,15 @@ struct OptMuxPushWorker
     // longest path if this operator sits on one. Anywhere else it duplicates
     // the operator for a win no endpoint ever sees.
     int slack = module_depth - path_depth(cell->getPort(ID::Y));
+    if (slack > slack_margin)
+      return false;
 
     if (push_merges_chain(cell, arm_a, arm_b)) {
       // The balancer reassociates the merged chain, so the payoff is not local
-      // and there is no gain here to compare the slack against.
+      // and there is no gain here to weigh.
       log_debug("    %s %s port %s: chain merge, slack=%d\n",
           log_id(cell->type), log_id(cell->name), log_id(port), slack);
-      return slack <= slack_margin;
+      return true;
     }
 
     int d_a = arrival(arm_a);
@@ -246,13 +248,10 @@ struct OptMuxPushWorker
 
     int before = std::max(std::max(std::max(d_a, d_b), d_s) + d_mux, others) + d_op;
     int after = std::max(std::max(std::max(d_a, d_b), others) + d_op, d_s) + d_mux;
-    int gain = before - after;
     log_debug("    %s %s port %s: dA=%d dB=%d dS=%d before=%d after=%d slack=%d\n",
         log_id(cell->type), log_id(cell->name), log_id(port), d_a, d_b, d_s,
         before, after, slack);
-    // A gain smaller than the slack is absorbed by the path that is actually
-    // critical, so require the push to reach it.
-    return gain > 0 && slack - slack_margin < gain;
+    return after < before;
   }
 
   void build_connectivity()
@@ -598,6 +597,10 @@ struct OptMuxPushPass : public Pass {
       if ((args[argidx] == "-slack-margin" || args[argidx] == "-slack_margin")
           && argidx+1 < args.size()) {
         slack_margin = atoi(args[++argidx].c_str());
+        // A negative margin would demand slack below zero, which no candidate
+        // can reach, so the guard would silently refuse everything.
+        if (slack_margin < 0)
+          log_cmd_error("muxpush: -slack-margin must not be negative.\n");
         continue;
       }
       break;

--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -71,19 +71,25 @@ struct OptMuxPushWorker
 
   dict<SigBit, RTLIL::Cell*> driver_map;
   dict<SigBit, int> fanout_map;
+  dict<SigBit, std::vector<RTLIL::Cell*>> consumer_map;
   dict<SigBit, int> arrival_cache;
   pool<SigBit> arrival_active;
+  dict<SigBit, int> depart_cache;
+  pool<SigBit> depart_active;
+  int module_depth;
 
   pool<IdString> target_types;
   int fanout_limit;
   bool timing_guard;
+  int slack_margin;
   int total_count;
 
   OptMuxPushWorker(RTLIL::Design *design, RTLIL::Module *module,
-      const pool<IdString> &target_types, int fanout_limit, bool timing_guard) :
-      design(design), module(module), sigmap(module),
+      const pool<IdString> &target_types, int fanout_limit, bool timing_guard,
+      int slack_margin) :
+      design(design), module(module), sigmap(module), module_depth(0),
       target_types(target_types), fanout_limit(fanout_limit),
-      timing_guard(timing_guard), total_count(0)
+      timing_guard(timing_guard), slack_margin(slack_margin), total_count(0)
   {
   }
 
@@ -126,6 +132,61 @@ struct OptMuxPushWorker
     return t;
   }
 
+  // Mirror of arrival_bit walking forward: levels from this bit to the latest
+  // endpoint that reads it. Registers and unread bits end a path.
+  int depart_bit(RTLIL::SigBit bit)
+  {
+    if (bit.wire == nullptr)
+      return 0;
+    auto it = depart_cache.find(bit);
+    if (it != depart_cache.end())
+      return it->second;
+    if (!depart_active.insert(bit).second)
+      return 0;
+    int result = 0;
+    auto it_cons = consumer_map.find(bit);
+    if (it_cons != consumer_map.end()) {
+      for (auto cons : it_cons->second) {
+        if (cons->is_builtin_ff())
+          continue;
+        int max_out = 0;
+        for (auto &conn : cons->connections()) {
+          if (!cons->output(conn.first))
+            continue;
+          for (auto &out_bit : sigmap(conn.second))
+            max_out = std::max(max_out, depart_bit(out_bit));
+        }
+        result = std::max(result, estimate_cell_delay(cons) + max_out);
+      }
+    }
+    depart_active.erase(bit);
+    depart_cache[bit] = result;
+    return result;
+  }
+
+  // Longest path through this signal, in the same unit-delay currency as the
+  // module's own depth.
+  int path_depth(const RTLIL::SigSpec &sig)
+  {
+    int t = 0;
+    for (auto &bit : sigmap(sig))
+      t = std::max(t, arrival_bit(bit) + depart_bit(bit));
+    return t;
+  }
+
+  void compute_module_depth()
+  {
+    module_depth = 0;
+    for (auto cell : module->cells()) {
+      for (auto &conn : cell->connections()) {
+        if (!cell->output(conn.first))
+          continue;
+        for (auto &bit : sigmap(conn.second))
+          module_depth = std::max(module_depth, arrival_bit(bit) + depart_bit(bit));
+      }
+    }
+  }
+
   // A mux between two associable operators blocks the arithmetic tree
   // balancer, so dissolving it pays even when the select arrives early.
   bool push_merges_chain(RTLIL::Cell *cell, const RTLIL::SigSpec &arm_a, const RTLIL::SigSpec &arm_b)
@@ -156,8 +217,20 @@ struct OptMuxPushWorker
   {
     if (!timing_guard)
       return true;
-    if (push_merges_chain(cell, arm_a, arm_b))
-      return true;
+
+    // Whatever depth the push buys locally, it can only shorten the module's
+    // longest path if this operator sits on one. Anywhere else it duplicates
+    // the operator for a win no endpoint ever sees.
+    int slack = module_depth - path_depth(cell->getPort(ID::Y));
+
+    if (push_merges_chain(cell, arm_a, arm_b)) {
+      // The balancer reassociates the merged chain, so the payoff is not local
+      // and there is no gain here to compare the slack against.
+      log_debug("    %s %s port %s: chain merge, slack=%d\n",
+          log_id(cell->type), log_id(cell->name), log_id(port), slack);
+      return slack <= slack_margin;
+    }
+
     int d_a = arrival(arm_a);
     int d_b = arrival(arm_b);
     int d_s = arrival(mux_cell->getPort(ID::S));
@@ -173,15 +246,20 @@ struct OptMuxPushWorker
 
     int before = std::max(std::max(std::max(d_a, d_b), d_s) + d_mux, others) + d_op;
     int after = std::max(std::max(std::max(d_a, d_b), others) + d_op, d_s) + d_mux;
-    log_debug("    %s %s port %s: dA=%d dB=%d dS=%d before=%d after=%d\n",
-        log_id(cell->type), log_id(cell->name), log_id(port), d_a, d_b, d_s, before, after);
-    return after < before;
+    int gain = before - after;
+    log_debug("    %s %s port %s: dA=%d dB=%d dS=%d before=%d after=%d slack=%d\n",
+        log_id(cell->type), log_id(cell->name), log_id(port), d_a, d_b, d_s,
+        before, after, slack);
+    // A gain smaller than the slack is absorbed by the path that is actually
+    // critical, so require the push to reach it.
+    return gain > 0 && slack - slack_margin < gain;
   }
 
   void build_connectivity()
   {
     driver_map.clear();
     fanout_map.clear();
+    consumer_map.clear();
 
     // Build per-bit driver and fanout maps for the current module
     for (auto cell : module->cells())
@@ -205,6 +283,9 @@ struct OptMuxPushWorker
             if (bit.wire == nullptr)
               continue;
             fanout_map[bit]++;
+            auto &cons = consumer_map[bit];
+            if (cons.empty() || cons.back() != cell)
+              cons.push_back(cell);
           }
         }
       }
@@ -306,6 +387,10 @@ struct OptMuxPushWorker
       build_connectivity();
       arrival_cache.clear();
       arrival_active.clear();
+      depart_cache.clear();
+      depart_active.clear();
+      if (timing_guard)
+        compute_module_depth();
 
       struct candidate_t {
         RTLIL::Cell *cell = nullptr;
@@ -428,6 +513,12 @@ struct OptMuxPushWorker
         RTLIL::Cell *new_mux = module->addMux(new_mux_name, out_a, out_b, mux_cell->getPort(ID::S), orig_y);
         new_mux->set_src_attribute(cell->get_src_attribute());
 
+        // Branch A evaluates one speculated arm now, not the original
+        // expression, so it must not keep the original name: equiv_make pairs
+        // cells by name and then requires their inputs to match, which is
+        // exactly what distributing the select breaks.
+        module->rename(branch_a, NEW_ID2_SUFFIX("mpa"));
+
         // Remove the original mux when it becomes dead after the rewrite. The
         // new mux only takes over the bits the operator read, so a bit outside
         // that slice still has a consumer of its own and the mux has to stay --
@@ -469,9 +560,15 @@ struct OptMuxPushPass : public Pass {
     log("        (default: $add,$sub,$xor)\n");
     log("\n");
     log("    -timing\n");
-    log("        only push when the push buys depth: either a unit-level delay\n");
-    log("        estimate says the select is the mux's late input, or the mux\n");
-    log("        splits a chain of associable operators\n");
+    log("        only push when the push buys depth on a path that is long\n");
+    log("        enough to matter: a unit-level delay estimate must say the\n");
+    log("        select is the mux's late input (or the mux must split a chain\n");
+    log("        of associable operators), and the operator must sit within\n");
+    log("        reach of the module's longest path\n");
+    log("\n");
+    log("    -slack-margin <int>\n");
+    log("        how many levels short of the longest path still counts as\n");
+    log("        critical for -timing (default: 0)\n");
     log("\n");
   }
 
@@ -479,6 +576,7 @@ struct OptMuxPushPass : public Pass {
   {
     int fanout_limit = 1;
     bool timing_guard = false;
+    int slack_margin = 0;
     std::string types = "$add,$sub,$xor";
 
     log_header(design, "Executing MUXPUSH pass (push muxes through light ops).\n");
@@ -497,6 +595,11 @@ struct OptMuxPushPass : public Pass {
         timing_guard = true;
         continue;
       }
+      if ((args[argidx] == "-slack-margin" || args[argidx] == "-slack_margin")
+          && argidx+1 < args.size()) {
+        slack_margin = atoi(args[++argidx].c_str());
+        continue;
+      }
       break;
     }
     extra_args(args, argidx, design);
@@ -512,7 +615,8 @@ struct OptMuxPushPass : public Pass {
     for (auto module : design->selected_modules()) {
       if (module->get_bool_attribute(ID::blackbox))
         continue;
-      OptMuxPushWorker worker(design, module, target_types, fanout_limit, timing_guard);
+      OptMuxPushWorker worker(design, module, target_types, fanout_limit, timing_guard,
+          slack_margin);
       worker.run();
       total_count += worker.total_count;
     }

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -279,3 +279,101 @@ select -assert-count 0 @add_fanin @mux_cells %i
 
 design -reset
 log -pop
+
+
+log -header "-timing: refuses a profitable push that is off the longest path"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [7:0] a,
+  input wire [7:0] b,
+  input wire [7:0] c,
+  input wire [7:0] d0,
+  input wire [7:0] d1,
+  input wire [7:0] d2,
+  input wire [7:0] d3,
+  output wire [7:0] y,
+  output wire [7:0] deep
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire s = sp[3];
+  wire [7:0] m = s ? b : a;
+  assign y = m + c;
+  wire [7:0] t0 = d0 * d1;
+  wire [7:0] t1 = t0 * d2;
+  wire [7:0] t2 = t1 * d3;
+  assign deep = t2 * d0;
+endmodule
+EOF
+proc
+check -assert
+design -save shallow_and_deep
+
+# The y cone is character for character the late-select case above, worth 4
+# levels, but the multiply chain to deep makes the module 32 levels deep and
+# leaves that cone 19 levels of slack. Buying 4 levels on a path with 19 to
+# spare cannot move the module's depth, so the duplicated adder would be pure
+# area.
+equiv_opt -assert muxpush -limit 1 -types $add -timing
+design -load postopt
+select -set add_fanin t:$add %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 1 @add_fanin @mux_cells %i
+design -reset
+
+# Same netlist with the slack allowance widened past 19 does push, so the group
+# above is the criticality guard declining a candidate the rest of the pass
+# accepts, not a match that never fired.
+design -load shallow_and_deep
+equiv_opt -assert muxpush -limit 1 -types $add -timing -slack-margin 24
+design -load postopt
+select -set add_fanin t:$add %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 0 @add_fanin @mux_cells %i
+
+design -reset
+log -pop
+
+
+log -header "A pushed operator does not keep the name of the operator it replaced"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [7:0] a,
+  input wire [7:0] b,
+  input wire [7:0] c,
+  output wire [7:0] y
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire s = sp[3];
+  wire [7:0] m = s ? b : a;
+  assign y = m + c;
+endmodule
+EOF
+proc
+check -assert
+
+# Branch A evaluates one speculated arm, so it must not answer to the name of
+# the operator that read the mux. equiv_make pairs cells by name and then
+# demands their inputs agree, and the pushed arm never agrees with the mux
+# output it replaced, so keeping the name reports the rewrite as inequivalent.
+# -inames pairs private names too, which is the strongest form of that matching
+# and the one this shape has to survive.
+design -save gold
+muxpush -limit 1 -types $add -timing
+design -stash gate
+design -copy-from gold -as gold top
+design -copy-from gate -as gate top
+equiv_make -inames gold gate equiv
+hierarchy -top equiv
+equiv_induct
+equiv_status -assert
+
+design -reset
+log -pop

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -377,3 +377,23 @@ equiv_status -assert
 
 design -reset
 log -pop
+
+
+log -header "-slack-margin rejects a negative allowance (ends the script, keep last)"
+log -push
+design -reset
+read_verilog <<EOF
+module top (input wire s, input wire [7:0] a, input wire [7:0] b, input wire [7:0] c,
+            output wire [7:0] y);
+  wire [7:0] m = s ? b : a;
+  assign y = m + c;
+endmodule
+EOF
+proc
+
+# A negative margin would demand slack below zero, which nothing reaches, so the
+# guard would quietly refuse every candidate instead of widening anything.
+logger -expect error "-slack-margin must not be negative" 1
+muxpush -limit 1 -types $add -timing -slack-margin -1
+logger -check-expected
+log -pop


### PR DESCRIPTION
`-timing` measured the depth a push buys at the operator itself, which says nothing about whether any endpoint sees it. Measured across the 85 designs in Preqorsor's `test_analyze_qor`, turning the pass on moved ten of them:

| | designs | worst case |
|---|---|---|
| LoL improved | 1 | opene902 sp1: 114 → 106.75, clk −70 |
| LoL got worse | 3 | spi sp0: +1.5 LoL, +4.4% area, clk +22 |
| LoL unchanged, area spent | 6 | tv80 sp1: +1.1% area |

## The guard

The pass now estimates levels both backward and forward, so a candidate is scored against the module's own depth instead of in isolation, and a push has to be able to reach the longest path. A gain smaller than the operator's slack is absorbed by whatever path is actually critical, so it buys a duplicated operator and nothing else.

The chain-merge exemption stays, because the balancer reassociates the merged chain and there is no local gain to compare against, but it is gated on the same criticality. `-slack-margin` widens what counts as critical for callers that want the old looseness.

After the guard, one design moves on LoL and it is the improvement. All three regressions and four of the six area-only pushes are gone; the two that remain (cv32e40p, both speeds) measure 0.00% area change. On opene902 the push takes the LoL prediction error against real synthesis from 42.5% to 33.4% and the clk error from 32.4% to 26.3%, for 0.4pp on area.

## Also: branch A kept a name it should not

The reused operator evaluates one speculated arm rather than the original expression, but it kept the original cell name. `equiv_make` pairs cells by public name and then asserts their inputs agree, which is precisely what distributing a select breaks. On a 320-bit popcount this reported 4 of 1318 `$equiv` cells unproven for a rewrite that is correct, and prover effort does not help — `equiv_simple -seq 8` plus `equiv_induct -seq 8` leave the same 4, because the manufactured comparison point genuinely is inequivalent. Renaming branch A removes the pairing and the same design proves in 0.10s.

## Tests

Two groups added to `tests/silimate/mux_push.ys`, both confirmed to fail when the corresponding half of the change is reverted:

- a cone worth 4 levels sitting 19 levels off a multiply chain is declined, and the same netlist pushes once `-slack-margin` is widened past the slack, so the group is the guard declining a candidate rather than a match that never fired
- the pushed shape survives `equiv_make -inames`, which pairs private names too and is the strongest form of that matching (8 unproven without the rename, 0 with it)

Full `tests/silimate` and `tests/opt` suites pass: 130 scripts, 0 failures.

Made with [Cursor](https://cursor.com)