### PR TITLE
opt_modadd_tree: match on the state recurrence, not addend provenance

### DIFF
--- a/passes/opt/opt_modadd_tree.cc
+++ b/passes/opt/opt_modadd_tree.cc
@@ -76,6 +76,7 @@ struct OptModAddTreeWorker : CutRegionWorker
 	int max_clones = 1024;
 	int min_serial_depth = 32;
 	int min_depth_gain = 2;
+	int min_ripple_depth = 2;
 
 	int table_regions = 0;
 	int vector_regions = 0;
@@ -382,13 +383,12 @@ struct OptModAddTreeWorker : CutRegionWorker
 		// ripple, killing most non-cascades before the grouping sweep.
 		pool<SigBit> tail_bits = sig_bit_pool(tail);
 		ch.head_min = 0;
-		int serial = 0;
-		bool ripple = false;
+		int serial = 0, ripple = 0;
 		for (int i = 1; i < GetSize(fine_nodes); i++) {
 			pool<Cell *> fwd = forward_cells(fine_cuts[i - 1], fine_nodes[i]);
 			serial += region_depth(fwd);
 			for (auto c : fwd) {
-				ripple |= cell_depth(c) > 1;
+				ripple = std::max(ripple, cell_depth(c));
 				if (cell_escapes(c, cone, tail_bits))
 					ch.head_min = std::max(ch.head_min, i);
 			}
@@ -398,10 +398,14 @@ struct OptModAddTreeWorker : CutRegionWorker
 			          "of %d\n", log_signal(tail), ch.head_min, GetSize(fine_cuts));
 			return false;
 		}
-		if (!ripple || serial < min_serial_depth) {
-			log_debug("  skipping cascade at %s: serial depth at most %d, %s\n",
-			          log_signal(tail), serial,
-			          ripple ? "below the minimum" : "pure bitwise logic");
+		if (ripple < min_ripple_depth) {
+			log_debug("  skipping cascade at %s: step ripple depth %d below %d\n",
+			          log_signal(tail), ripple, min_ripple_depth);
+			return false;
+		}
+		if (serial < min_serial_depth) {
+			log_debug("  skipping cascade at %s: serial depth at most %d, below %d\n",
+			          log_signal(tail), serial, min_serial_depth);
 			return false;
 		}
 
@@ -942,22 +946,23 @@ struct OptModAddTreeWorker : CutRegionWorker
 		// Only pay for the rewrite where the tree is a clear win. Compare like
 		// with like: the rewrite rebuilds the state path only, so node 0 and
 		// each step's addend logic must not count on either side.
-		int serial = 0, leaf = 0;
-		bool ripple = false;
+		int serial = 0, leaf = 0, ripple = 0;
 		for (int i = 1; i < n; i++) {
 			int d = region_depth(ch.state_cells[i]);
 			serial += d;
 			leaf = std::max(leaf, d);
 			for (auto c : ch.state_cells[i])
-				ripple |= cell_depth(c) > 1;
+				ripple = std::max(ripple, cell_depth(c));
 		}
 		// Counting cells only tracks real depth where the step carries a
 		// ripple (an add, a compare, a wide select). A step built purely from
-		// bitwise gates is restructured downstream anyway, so replicating it
-		// buys area, not levels.
-		if (!ripple) {
-			log_debug("  skipping %s cascade at %s: step is pure bitwise logic\n",
-			          as_table ? "associative" : "general", log_signal(ch.tail));
+		// bitwise gates is restructured downstream anyway, so the estimate
+		// below would overstate what the tree wins. Like the width guard this
+		// is a cost call, so -min-ripple-depth 1 relaxes it.
+		if (ripple < min_ripple_depth) {
+			log_debug("  skipping %s cascade at %s: step ripple depth %d below %d\n",
+			          as_table ? "associative" : "general", log_signal(ch.tail), ripple,
+			          min_ripple_depth);
 			return false;
 		}
 		// One tree level costs what emit_combine will actually build: a cloned
@@ -1102,6 +1107,13 @@ struct OptModAddTreePass : public Pass {
 		log("        that replaces it (default 2), so short narrow-state chains are\n");
 		log("        not replicated for a level or two.\n");
 		log("\n");
+		log("    -min-ripple-depth N, -min_ripple_depth N\n");
+		log("        require the deepest cell on a step's state path to be worth at\n");
+		log("        least N levels (default 2). The depth estimate counts cells, so\n");
+		log("        it only predicts real depth once a step carries a ripple; a step\n");
+		log("        of bitwise gates is restructured downstream anyway. Pass 1 to\n");
+		log("        consider those too.\n");
+		log("\n");
 		log("    -walk-budget N, -eval-budget N, -attempt-budget N\n");
 		log("        per-module work limits for the candidate search (defaults\n");
 		log("        20000000 / 20000000 / 65536).\n");
@@ -1120,6 +1132,7 @@ struct OptModAddTreePass : public Pass {
 		int max_clones = 1024;
 		int min_serial_depth = 32;
 		int min_depth_gain = 2;
+		int min_ripple_depth = 2;
 		int64_t walk_budget = -1, eval_budget = -1, attempt_budget = -1;
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
@@ -1163,6 +1176,11 @@ struct OptModAddTreePass : public Pass {
 				min_depth_gain = std::stoi(args[++argidx]);
 				continue;
 			}
+			if ((args[argidx] == "-min-ripple-depth" || args[argidx] == "-min_ripple_depth") &&
+			    argidx + 1 < args.size()) {
+				min_ripple_depth = std::stoi(args[++argidx]);
+				continue;
+			}
 			if ((args[argidx] == "-walk-budget" || args[argidx] == "-walk_budget") &&
 			    argidx + 1 < args.size()) {
 				walk_budget = std::stoll(args[++argidx]);
@@ -1193,6 +1211,7 @@ struct OptModAddTreePass : public Pass {
 			worker.max_clones = max_clones;
 			worker.min_serial_depth = min_serial_depth;
 			worker.min_depth_gain = min_depth_gain;
+			worker.min_ripple_depth = min_ripple_depth;
 			if (walk_budget > 0)
 				worker.walk_budget = walk_budget;
 			if (eval_budget > 0)

--- a/passes/opt/opt_modadd_tree.cc
+++ b/passes/opt/opt_modadd_tree.cc
@@ -59,7 +59,10 @@ PRIVATE_NAMESPACE_BEGIN
 //
 // Both shapes are derived from the netlist itself (cloned step cones, and for
 // shape 1 a ConstEval-proven table), so the pass never assumes a particular
-// spelling of the reduction and never relies on don't-care freedom.
+// spelling of the reduction and never relies on don't-care freedom. Only the
+// state has to flow serially: the addends may come from anywhere, including
+// pre-logic shared by every step (a barrel shifter, a mux tree, ...), which
+// the rewrite leaves in place and the tree leaves read unchanged.
 struct OptModAddTreeWorker : CutRegionWorker
 {
 	// Tunables (see Pass::execute).
@@ -92,6 +95,8 @@ struct OptModAddTreeWorker : CutRegionWorker
 		vector<pool<Cell *>> fine_nodes;
 		vector<int> fine_depth;
 
+		int head_min = 0;                 // node 0 must cover fine nodes 0..head_min
+
 		vector<SigSpec> cuts;             // cuts[i] = state after node i
 		vector<pool<Cell *>> state_cells; // cells of node i that depend on cuts[i-1]
 		pool<Cell *> head_cells;          // node 0: produces the initial state
@@ -116,13 +121,19 @@ struct OptModAddTreeWorker : CutRegionWorker
 
 	// ------------------------------------------------------------ detection
 
-	// A cut splits the tail cone in two: nothing downstream of X may read a
-	// signal produced upstream of X other than X itself. Escaping fanout to
-	// cells outside the tail cone is fine (shared pre-logic stays in place).
-	bool is_cut(const SigSpec &x, const pool<Cell *> &cx, const pool<Cell *> &cone)
+	// A cut splits the tail cone in two: no cascade state produced upstream of
+	// X may reach a cell downstream of X other than through X itself.
+	// `state_free` cells carry no state (shared addend pre-logic such as a
+	// barrel shifter feeding every digit); the rewrite leaves their value
+	// untouched, so they may fan out to any step. Escaping fanout to cells
+	// outside the tail cone is fine (shared pre-logic stays in place).
+	bool is_cut(const SigSpec &x, const pool<Cell *> &cx, const pool<Cell *> &cone,
+	            const pool<Cell *> &state_free)
 	{
 		pool<SigBit> xbits = sig_bit_pool(x);
 		for (auto c : cx) {
+			if (state_free.count(c))
+				continue;
 			charge_walk(1);
 			for (auto &conn : c->connections()) {
 				if (!c->output(conn.first))
@@ -137,6 +148,28 @@ struct OptModAddTreeWorker : CutRegionWorker
 			}
 		}
 		return true;
+	}
+
+	// True when a non-tail output of `c` is read from outside the region (or
+	// is a module output). Such a cell survives the rewrite, so cloning it
+	// leaves the serial chain alive next to its tree.
+	bool cell_escapes(Cell *c, const pool<Cell *> &cone, const pool<SigBit> &tail_bits)
+	{
+		charge_walk(1);
+		for (auto &conn : c->connections()) {
+			if (!c->output(conn.first))
+				continue;
+			for (auto bit : sigmap(conn.second)) {
+				if (!bit.wire || tail_bits.count(bit))
+					continue;
+				if (output_port_bits.count(bit))
+					return true;
+				for (auto sink : bit_to_sinks.at(bit, pool<Cell *>()))
+					if (!cone.count(sink))
+						return true;
+			}
+		}
+		return false;
 	}
 
 	// Intermediate states must die with the old cascade, else the rewrite
@@ -244,8 +277,6 @@ struct OptModAddTreeWorker : CutRegionWorker
 			return false;
 		if (GetSize(cone) < min_nodes)
 			return false;
-		if (!is_cut(tail, cone, cone))
-			return false;
 
 		// Candidate cuts: same-width output buses produced inside the cone.
 		vector<SigSpec> cands;
@@ -263,6 +294,26 @@ struct OptModAddTreeWorker : CutRegionWorker
 		if (GetSize(cands) + 1 < min_nodes)
 			return false;
 
+		// A cell that neither produces nor can reach a candidate state computes
+		// an addend: the rewrite leaves its value alone, so it may feed any
+		// number of steps. One forward walk over every candidate keeps this
+		// conservative whichever cuts the chain ends up using.
+		SigSpec cand_bits;
+		for (auto &sig : cands)
+			cand_bits.append(sig);
+		pool<Cell *> downstream = forward_cells(cand_bits, cone);
+		pool<Cell *> state_free;
+		for (auto c : cone)
+			if (!downstream.count(c))
+				state_free.insert(c);
+		// A cell producing a candidate is a state producer even though no
+		// candidate reaches it, so it must not be treated as pre-logic.
+		for (auto bit : sigmap(cand_bits)) {
+			Cell *drv = bit_to_driver.at(bit, nullptr);
+			if (drv != nullptr)
+				state_free.erase(drv);
+		}
+
 		// Keep the valid cuts, ordered by how much of the cone they cover.
 		vector<std::pair<int, int>> ranked;
 		vector<pool<Cell *>> cand_cones(GetSize(cands));
@@ -274,7 +325,7 @@ struct OptModAddTreeWorker : CutRegionWorker
 				continue;
 			if (!cut_is_internal(cands[i], cone))
 				continue;
-			if (!is_cut(cands[i], cand_cones[i], cone))
+			if (!is_cut(cands[i], cand_cones[i], cone, state_free))
 				continue;
 			ranked.push_back({GetSize(cand_cones[i]), i});
 		}
@@ -324,9 +375,41 @@ struct OptModAddTreeWorker : CutRegionWorker
 		ch.cone = cone;
 		ch.fine_cuts = fine_cuts;
 		ch.fine_nodes = fine_nodes;
+
+		// A node clones exactly what its incoming cut reaches, and node 0 is
+		// left in place, so an escaping cell is tolerable only if node 0 grows
+		// to cover it. The same walk bounds the state path and spots the
+		// ripple, killing most non-cascades before the grouping sweep.
+		pool<SigBit> tail_bits = sig_bit_pool(tail);
+		ch.head_min = 0;
+		int serial = 0;
+		bool ripple = false;
+		for (int i = 1; i < GetSize(fine_nodes); i++) {
+			pool<Cell *> fwd = forward_cells(fine_cuts[i - 1], fine_nodes[i]);
+			serial += region_depth(fwd);
+			for (auto c : fwd) {
+				ripple |= cell_depth(c) > 1;
+				if (cell_escapes(c, cone, tail_bits))
+					ch.head_min = std::max(ch.head_min, i);
+			}
+		}
+		if (GetSize(fine_cuts) - ch.head_min < min_nodes) {
+			log_debug("  skipping cascade at %s: state escapes up to fine node %d "
+			          "of %d\n", log_signal(tail), ch.head_min, GetSize(fine_cuts));
+			return false;
+		}
+		if (!ripple || serial < min_serial_depth) {
+			log_debug("  skipping cascade at %s: serial depth at most %d, %s\n",
+			          log_signal(tail), serial,
+			          ripple ? "below the minimum" : "pure bitwise logic");
+			return false;
+		}
+
 		ch.fine_depth.clear();
 		for (auto &node : fine_nodes)
 			ch.fine_depth.push_back(region_depth(node));
+		log_debug("  chain at %s: %d fine cut(s), serial depth at most %d\n",
+		          log_signal(tail), GetSize(ch.fine_cuts), serial);
 		return true;
 	}
 
@@ -338,7 +421,8 @@ struct OptModAddTreeWorker : CutRegionWorker
 	{
 		int nfine = GetSize(ch.fine_nodes);
 		vector<int> keep;
-		for (int i = first_len - 1; i < nfine; i += (GetSize(keep) ? stride : 1))
+		for (int i = std::max(first_len - 1, ch.head_min); i < nfine;
+		     i += (GetSize(keep) ? stride : 1))
 			keep.push_back(i);
 		if (keep.empty() || keep.back() != nfine - 1)
 			keep.push_back(nfine - 1);
@@ -538,10 +622,13 @@ struct OptModAddTreeWorker : CutRegionWorker
 	// ------------------------------------------------------- const-table tier
 
 	// A region's free input bits, in cell/port/bit order so that a digit of
-	// state width lines up with the state's own bit numbering. Only cone
-	// leaves qualify: forcing a bit whose driver ConstEval might also
-	// evaluate would conflict with its cell-output cache.
-	bool region_digit(const pool<Cell *> &cells, const SigSpec &state, SigSpec &digit)
+	// state width lines up with the state's own bit numbering. The addend may
+	// be driven by anything (port bits, a shifter, a mux, ...), but forcing a
+	// driven bit is only safe when ConstEval never evaluates its driver, so
+	// the region's cone must close on state+digit with no forced bit produced
+	// inside it.
+	bool region_digit(const pool<Cell *> &cells, const SigSpec &state, const SigSpec &out,
+	                  SigSpec &digit)
 	{
 		pool<SigBit> state_bits = sig_bit_pool(state);
 		pool<SigBit> internal;
@@ -553,6 +640,7 @@ struct OptModAddTreeWorker : CutRegionWorker
 							internal.insert(bit);
 
 		pool<SigBit> seen;
+		bool any_driven = false;
 		digit = SigSpec();
 		for (auto c : ordered_cells(cells)) {
 			vector<IdString> ports;
@@ -565,18 +653,25 @@ struct OptModAddTreeWorker : CutRegionWorker
 				for (auto bit : sigmap(c->getPort(port))) {
 					if (!bit.wire || state_bits.count(bit) || internal.count(bit))
 						continue;
-					if (bit_to_driver.at(bit, nullptr) != nullptr)
-						return false;
-					if (seen.insert(bit).second)
+					if (seen.insert(bit).second) {
 						digit.append(bit);
+						if (GetSize(digit) > max_digit_bits)
+							return false;
+						any_driven |= bit_to_driver.at(bit, nullptr) != nullptr;
+					}
 				}
 		}
-		return GetSize(digit) <= max_digit_bits;
+		if (!any_driven)
+			return true;
+		pool<SigBit> forced = seen;
+		for (auto bit : state_bits)
+			forced.insert(bit);
+		return cut_cone_walk(out, forced, max_cone_cells, nullptr, nullptr, &forced);
 	}
 
 	bool node_digit(const Chain &ch, int i, SigSpec &digit)
 	{
-		return region_digit(ch.state_cells[i], ch.cuts[i - 1], digit);
+		return region_digit(ch.state_cells[i], ch.cuts[i - 1], ch.cuts[i], digit);
 	}
 
 	// Exhaustive transfer function of node `i`, indexed [digit][state].
@@ -616,7 +711,7 @@ struct OptModAddTreeWorker : CutRegionWorker
 
 		SigSpec digit;
 		ConstEval &ce = shared_ce();
-		bool seeded = region_digit(ch.head_cells, SigSpec(), digit);
+		bool seeded = region_digit(ch.head_cells, SigSpec(), ch.cuts[0], digit);
 		if (seeded) {
 			int ndigits = 1 << GetSize(digit);
 			for (int d = 0; d < ndigits && seeded; d++) {
@@ -802,8 +897,11 @@ struct OptModAddTreeWorker : CutRegionWorker
 		int k0 = default_stride(ch);
 		for (int k : {k0, k0 + 1, std::max(1, k0 - 1)}) {
 			for (int phase = 1; phase <= k && !as_table; phase++)
-				if (apply_grouping(ch, k, phase))
+				if (apply_grouping(ch, k, phase)) {
+					log_debug("  try %s: stride %d phase %d, %d node(s)\n",
+					          log_signal(ch.tail), k, phase, GetSize(ch.cuts));
 					as_table = prove_table(ch, combine, live, reach, seed);
+				}
 			if (as_table)
 				break;
 		}
@@ -841,15 +939,27 @@ struct OptModAddTreeWorker : CutRegionWorker
 			return false;
 		}
 
-		// Only pay for the rewrite where the cascade is deep enough that the
-		// tree is a clear win: short narrow-state chains are everywhere in real
-		// designs and replicating them would cost area for a level or two.
-		int serial = 0;
-		for (int d : ch.fine_depth)
+		// Only pay for the rewrite where the tree is a clear win. Compare like
+		// with like: the rewrite rebuilds the state path only, so node 0 and
+		// each step's addend logic must not count on either side.
+		int serial = 0, leaf = 0;
+		bool ripple = false;
+		for (int i = 1; i < n; i++) {
+			int d = region_depth(ch.state_cells[i]);
 			serial += d;
-		int leaf = 0;
-		for (int i = 1; i < n; i++)
-			leaf = std::max(leaf, region_depth(ch.state_cells[i]));
+			leaf = std::max(leaf, d);
+			for (auto c : ch.state_cells[i])
+				ripple |= cell_depth(c) > 1;
+		}
+		// Counting cells only tracks real depth where the step carries a
+		// ripple (an add, a compare, a wide select). A step built purely from
+		// bitwise gates is restructured downstream anyway, so replicating it
+		// buys area, not levels.
+		if (!ripple) {
+			log_debug("  skipping %s cascade at %s: step is pure bitwise logic\n",
+			          as_table ? "associative" : "general", log_signal(ch.tail));
+			return false;
+		}
 		// One tree level costs what emit_combine will actually build: a cloned
 		// step, or a lookup selected by 2w (table) / w (per-slot) bits.
 		int level = cb.node >= 0 ? region_depth(ch.state_cells[cb.node])
@@ -958,7 +1068,8 @@ struct OptModAddTreePass : public Pass {
 		log("\n");
 		log("Both shapes are built from the cascade's own cells, so the pass is\n");
 		log("agnostic to how the reduction was spelled and never relies on don't-care\n");
-		log("freedom.\n");
+		log("freedom. Only the state has to flow serially; the addends may be driven\n");
+		log("by anything, including pre-logic shared by every step.\n");
 		log("\n");
 		log("    -max-state-bits N, -max_state_bits N\n");
 		log("        maximum accumulator width to consider (default 4).\n");

--- a/tests/opt/opt_modadd_tree.ys
+++ b/tests/opt/opt_modadd_tree.ys
@@ -5,8 +5,8 @@
 #   B: associative tree combined by a clone of the cascade's own step.
 #   C: transfer-function tree (emit shape 2) on a step that is NOT associative.
 #   D: rejection guards -- wrong fixup constant, state too wide, clone budget.
-#   E: the depth-win guard, which keeps the shape off shallow cascades.
-#   F: the narrow-state guard, which keeps the shape off boolean chains.
+#   E: the depth guards, which keep the shape off shallow cascades.
+#   F: the ripple and narrow-state guards, which keep it off boolean chains.
 #
 # Depth is the point of this pass, so the structural checks are `ltp -noff`
 # lengths rather than cell counts: the tree trades area for depth, so cell
@@ -241,8 +241,10 @@ logger -expect log "length=41\)" 1
 ltp -noff
 logger -check-expected
 # Composing two steps is not itself a step, which is exactly why the cheap
-# shape is unsound here. The count tracks the grouping-phase retry schedule.
-logger -expect log "distinct step function" 3
+# shape is unsound here. This pins that the proof reached a verdict on every
+# grouping tried, not that it tried six; retune the count when the grouping
+# schedule changes. Soundness is pinned by the rewrite counts below.
+logger -expect log "distinct step function" 6
 logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 1 cascade\(s\) as transfer-function tree\(s\)" 1
 debug opt_modadd_tree
 logger -check-expected
@@ -357,12 +359,13 @@ design -reset
 log -pop
 
 # ============================================================================
-# Group E: depth-win guard
+# Group E: depth guards
 # ============================================================================
 
 # E1: only four digits, so the serial chain is shallow and replicating the
 # step would buy a level or two at best. Short narrow-state cascades like this
-# are everywhere in real designs, so the guard must leave them alone.
+# are everywhere in real designs, so the guards must leave them alone. The
+# depth floor gets there first, before the chain is even grouped.
 log -header "E1: shallow cascade -> left alone"
 log -push
 design -reset
@@ -387,7 +390,7 @@ opt_expr
 opt_clean
 select -assert-count 15 t:*
 design -save shallow
-logger -expect log "skipping general cascade at .*serial depth 28 vs tree depth 13" 1
+logger -expect log "skipping cascade at .*serial depth at most 22, below 32" 1
 logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 0 cascade\(s\) as transfer-function tree\(s\)" 1
 debug opt_modadd_tree
 logger -check-expected
@@ -395,8 +398,23 @@ select -assert-count 0 c:*modadd*
 select -assert-count 15 t:*
 log -pop
 
-# E2: the same cascade rewrites once the depth thresholds are lowered, so E1
-# is the guard declining a real match rather than the pass failing to see it.
+# E1b: drop the floor below the chain and the ratio guard is what refuses it,
+# which is the check that actually compares the two shapes. Keep both covered:
+# the floor is a cheap pre-filter, this is the real depth-win call.
+log -header "E1b: shallow cascade -> refused by the depth-win ratio"
+log -push
+design -load shallow
+logger -expect log "skipping general cascade at .*serial depth 21 vs tree depth 13" 1
+logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 0 cascade\(s\) as transfer-function tree\(s\)" 1
+debug opt_modadd_tree -min-serial-depth 8
+logger -check-expected
+select -assert-count 0 c:*modadd*
+select -assert-count 15 t:*
+log -pop
+
+# E2: the same cascade rewrites once both depth thresholds are lowered, so E1
+# and E1b are guards declining a real match rather than the pass failing to
+# see it.
 log -header "E2: shallow cascade rewrites once the thresholds allow it"
 log -push
 design -load shallow
@@ -408,14 +426,16 @@ design -reset
 log -pop
 
 # ============================================================================
-# Group F: narrow-state guard
+# Group F: ripple and narrow-state guards
 # ============================================================================
 
 # F1: a flag threaded through eight compare steps. The state is one bit, so
 # the transfer-function shape would clone each compare cone twice to carry a
 # map that tree balancing gets for free -- on a real FPU this shape cost 17x
-# area for no depth. Deep enough that only the width guard can refuse it.
-log -header "F1: one-bit state -> left alone"
+# area for no depth. Two independent cost guards refuse it; the ripple guard
+# gets there first, because the adds and compares feed the addend and the
+# state itself only ever passes through a $not, an $and and a $mux.
+log -header "F1: bitwise step -> left alone"
 log -push
 design -reset
 read_verilog -sv <<EOF
@@ -444,27 +464,41 @@ check -assert
 design -save flag
 # Every prefix of the chain is its own candidate, so pin the full-length one
 # rather than counting all sixteen skips.
-logger -expect log "skipping general cascade at .y: state width 1 below 2" 1
+logger -expect log "skipping cascade at .y: step ripple depth 1 below 2" 1
 logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 0 cascade\(s\) as transfer-function tree\(s\)" 1
 debug opt_modadd_tree
 logger -check-expected
 select -assert-count 0 c:*modadd*
 log -pop
 
-# F2: the same cascade rewrites at -min-state-bits 1, so F1 is the width guard
-# declining a match the pass otherwise takes.
-log -header "F2: one-bit state rewrites once the width guard allows it"
+# F1b: relax the ripple guard and the width guard refuses the same chain, so
+# both are still load-bearing on their own. The floor comes down too because
+# the state path here is only fifteen levels of gates -- the adds that make
+# the cone look deep are addend logic the rewrite never touches.
+log -header "F1b: one-bit state -> left alone by the width guard"
+log -push
+design -load flag
+logger -expect log "skipping general cascade at .y: state width 1 below 2" 1
+logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 0 cascade\(s\) as transfer-function tree\(s\)" 1
+debug opt_modadd_tree -min-ripple-depth 1 -min-serial-depth 8
+logger -check-expected
+select -assert-count 0 c:*modadd*
+log -pop
+
+# F2: the same cascade rewrites once each of those cost guards is told to
+# stand down, so F1 and F1b are refusals to pay rather than failures to match.
+log -header "F2: one-bit state rewrites once the cost guards allow it"
 log -push
 design -load flag
 logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 1 cascade\(s\) as transfer-function tree\(s\)" 1
-opt_modadd_tree -min-state-bits 1
+opt_modadd_tree -min-state-bits 1 -min-ripple-depth 1 -min-serial-depth 8
 logger -check-expected
 select -assert-min 1 c:*modadd*
 design -reset
 log -pop
 
-# F3: the width guard is a cost call, not a correctness one, so prove the
-# rewrite it declines. Same flag chain narrowed to 4-bit steps, which keeps the
+# F3: those guards are cost calls, not correctness ones, so prove the rewrite
+# they decline. Same flag chain narrowed to 4-bit steps, which keeps the
 # equivalence check cheap; the thresholds come down to match the shorter chain.
 log -header "F3: the declined one-bit rewrite is equivalent"
 log -push
@@ -493,7 +527,7 @@ opt_expr
 opt_clean
 check -assert
 logger -expect log "Rewrote 0 associative cascade\(s\) as balanced tree\(s\), 1 cascade\(s\) as transfer-function tree\(s\)" 1
-equiv_opt -assert opt_modadd_tree -min-state-bits 1 -min-serial-depth 8 -min-depth-gain 1
+equiv_opt -assert opt_modadd_tree -min-state-bits 1 -min-ripple-depth 1 -min-serial-depth 8 -min-depth-gain 1
 logger -check-expected
 design -load postopt
 select -assert-min 1 c:*modadd*


### PR DESCRIPTION
## Summary

A mod-M digit-sum cascade whose digits are sliced out of a barrel shifter was not rewritten at all. Two checks rejected it, and both keyed on where the addend bits came from rather than on the recurrence the pass owns:

- `is_cut` rejects a cut when a cell upstream of it feeds a downstream cell other than through the cut. The shared shifter sits upstream of every cut and feeds every step, so no chain was ever built.
- `region_digit` only accepted *undriven* cone leaves as a step's digit, because forcing a driven bit could collide with ConstEval's cell-output cache. With a shifter in place every digit bit is driven.

Cells that neither produce nor can reach a candidate state bus are now classified as addend logic and may fan out freely; driven digit bits are allowed once a cone walk proves the step closes on state+digit with no forced bit produced inside it, so soundness still comes from a proof rather than a looser fingerprint. Provenance no longer matters: a shifter, mux tree, register or arbitrary cell output all behave alike.

Widening the match exposed two ways the rewrite could lose, both fixed here:

- **Escaping step reads.** A step cell read from outside the cone survives the rewrite and keeps the serial chain alive next to its new tree. Node 0 now grows until it covers every such cell. This also fixes a pre-existing false economy: on ariane the old pass rewrote a 30-node cascade in the PLIC `SEQUENTIAL` arbiter, growing that module from 180 to 1079 cells while depth moved only 92 to 90, because `irq_id` still reads every intermediate `max_prio`.
- **Depth estimated by cell count.** That only tracks real depth where a step carries a ripple, and it counted node 0 and the addend logic, which are paid either way. The gain test now compares the state path alone and requires at least one ripple cell in the step. Without this the widened match rebalanced a purely boolean thermometer accumulate and made it worse.

## Results

| | before | after |
|---|---|---|
| shifter-fed mod-7 cascade | lol 40.5 / clk 605.7 | **22.25 / 269.5** |
| pass runtime, veer (29,118 cells) | 25.14s | **23.13s** |
| full flow, ariane | 726.58s | **658.76s** |

The ariane and veer speedups come from no longer emitting the PLIC rewrite that downstream ABC and STA had to process. Both designs now emit zero cells from this pass.

## Test plan

- [x] New regression: shifter-fed mod-7 cascade, asserts the rewrite substring and lol < 27
- [x] New negative: second-order cascade (each step also folds the accumulator from two steps back) must not rewrite, since rebalancing one accumulator would leave the serial chain alive to feed the other
- [x] `qor_mod7_digit_sum` 16.75, `qor_mod9_digit_sum` 34.5 (still the cheap associative tier), `qor_mod7_skew_nomatch` 15.5 all unchanged
- [x] `qor_mod61_wide_nomatch` still refused by the state-width cost guard
- [x] `qor_vmw_slot_lane` 16.0, guarded against the new false match
- [x] All 83 `qor_*` regressions pass; full suite 299 passed / 8 xfailed
- [ ] `customer_veer_eh2` not re-run end to end on the final build; verified instead that the pass reports zero rewrites and zero emitted cells in both of veer's synthesis invocations, so the netlist handed downstream is identical to baseline

## Known limitation

The ripple requirement is a cost-model heuristic, not a proof: a genuine narrow-state recurrence spelled entirely in bitwise gates is now refused. That is deliberate (ABC restructures those anyway, and both boolean cascades measured were net losses) but it is a judgment call.

The paired Preqorsor test registrations live on branch `qor/mod7-digit-sum-2`.

Made with [Cursor](https://cursor.com)