### PR TITLE
[CUS-662] Add src attributions to memkill generated cells

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,7 @@ yosys_core(everything BOOTSTRAP)
 
 # All of the source code.
 add_subdirectory(libs)
+link_libraries(backward)
 add_subdirectory(kernel)
 add_subdirectory(passes)
 add_subdirectory(frontends)

--- a/cmake/SilimateConfig.cmake
+++ b/cmake/SilimateConfig.cmake
@@ -20,4 +20,3 @@ if (APPLE)
 endif()
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/libs/backward-cpp)
-link_libraries(backward)

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -238,6 +238,7 @@ struct MemoryMapWorker
 					c->setPort(ID::CLK, refclock);
 				}
 				c->parameters[ID::WIDTH] = mem.width;
+				c->set_src_attribute(mem.get_src_attribute()); // SILIMATE: add src attribute to the cell
 
 				RTLIL::Wire *w_in = module->addWire(genid(mem.memid, "", addr, "$d"), mem.width);
 				data_reg_in[idx] = w_in;

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -107,6 +107,9 @@ struct MemoryMapWorker
 		std::set<int> static_ports;
 		std::map<int, RTLIL::SigSpec> static_cells_map;
 
+		// Source location of the memory; every cell and wire we lower it into inherits it
+		std::string src = mem.get_src_attribute();
+
 		SigSpec init_data = mem.get_init_data();
 
 		if (!mem.wr_ports.empty() && rom_only)
@@ -238,9 +241,10 @@ struct MemoryMapWorker
 					c->setPort(ID::CLK, refclock);
 				}
 				c->parameters[ID::WIDTH] = mem.width;
-				c->set_src_attribute(mem.get_src_attribute()); // SILIMATE: add src attribute to the cell
+				c->set_src_attribute(src); // SILIMATE: attribute the FFRAM entry
 
 				RTLIL::Wire *w_in = module->addWire(genid(mem.memid, "", addr, "$d"), mem.width);
+				w_in->set_src_attribute(src); // SILIMATE: attribute the FFRAM entry D wire
 				data_reg_in[idx] = w_in;
 				c->setPort(ID::D, w_in);
 
@@ -249,6 +253,7 @@ struct MemoryMapWorker
 					w_out_name = genid(mem.memid, "", addr, "$q");
 
 				RTLIL::Wire *w_out = module->addWire(w_out_name, mem.width);
+				w_out->set_src_attribute(src); // SILIMATE: attribute the FFRAM entry Q wire
 
 				if (formal && mem.packed && mem.cell->name.c_str()[0] == '\\') {
 					auto hdlname = mem.cell->get_hdlname_attribute();
@@ -295,10 +300,15 @@ struct MemoryMapWorker
 					c->parameters[ID::WIDTH] = GetSize(port.data);
 					c->setPort(ID::Y, rd_signals[k]);
 					c->setPort(ID::S, rd_addr.extract(abits-j-1, 1));
+					c->set_src_attribute(src); // SILIMATE: attribute the FFRAM read mux
 					count_mux++;
 
-					c->setPort(ID::A, module->addWire(genid(mem.memid, "$rdmux", i, "", j, "", k, "$a"), GetSize(port.data)));
-					c->setPort(ID::B, module->addWire(genid(mem.memid, "$rdmux", i, "", j, "", k, "$b"), GetSize(port.data)));
+					RTLIL::Wire *w_a = module->addWire(genid(mem.memid, "$rdmux", i, "", j, "", k, "$a"), GetSize(port.data));
+					RTLIL::Wire *w_b = module->addWire(genid(mem.memid, "$rdmux", i, "", j, "", k, "$b"), GetSize(port.data));
+					w_a->set_src_attribute(src); // SILIMATE: attribute the FFRAM read mux A wire
+					w_b->set_src_attribute(src); // SILIMATE: attribute the FFRAM read mux B wire
+					c->setPort(ID::A, w_a);
+					c->setPort(ID::B, w_b);
 
 					next_rd_signals.push_back(c->getPort(ID::A));
 					next_rd_signals.push_back(c->getPort(ID::B));
@@ -358,8 +368,10 @@ struct MemoryMapWorker
 							c->parameters[ID::Y_WIDTH] = RTLIL::Const(1);
 							c->setPort(ID::A, w);
 							c->setPort(ID::B, wr_bit);
+							c->set_src_attribute(src); // SILIMATE: attribute the FFRAM write-enable
 
 							w = module->addWire(genid(mem.memid, "$wren", addr, "", j, "", wr_offset, "$y"));
+							w->set_src_attribute(src); // SILIMATE: attribute the FFRAM write-enable Y wire
 							c->setPort(ID::Y, RTLIL::SigSpec(w));
 						}
 
@@ -368,8 +380,10 @@ struct MemoryMapWorker
 						c->setPort(ID::A, sig.extract(wr_offset, wr_width));
 						c->setPort(ID::B, port.data.extract(wr_offset + sub * mem.width, wr_width));
 						c->setPort(ID::S, RTLIL::SigSpec(w));
+						c->set_src_attribute(src); // SILIMATE: attribute the FFRAM write mux
 
 						w = module->addWire(genid(mem.memid, "$wrmux", addr, "", j, "", wr_offset, "$y"), wr_width);
+						w->set_src_attribute(src); // SILIMATE: attribute the FFRAM write mux Y wire
 						c->setPort(ID::Y, w);
 
 						sig.replace(wr_offset, w);


### PR DESCRIPTION
## Root cause
In `passes/memory/memory_map.cc`, address decoders already got `mem.get_src_attribute()`, but these creates did not:
- entry `$dff` / `$ff` cells
- entry `$d` / `$q` wires
- `$rdmux` cells and A/B wires
- `$wren` cells and Y wires
- `$wrmux` cells and Y wires
`addCell` / `addWire` start with an empty attribute dict, so the memory's RTL `src` was dropped at lowering.

## Fix
In `handle_memory`, hoist `std::string src = mem.get_src_attribute()` and call `set_src_attribute(src)` on every cell/wire created while lowering the memory to FFRAM. Entry flops and the rdmux/wren/wrmux cone now keep the memory's source location (e.g. the RTL `entries` declaration).
With a real `src` present, `ffnormpol`'s lookup hits instead of missing, so no empty `Const` is inserted.