### PR TITLE
[CUS-661] - Fix stack overflow on depart/arrival bit calculations in 'muxpush'

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <set>
+#include <vector>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -92,36 +93,78 @@ struct OptMuxPushWorker
       timing_guard(timing_guard), slack_margin(slack_margin), total_count(0)
   {
   }
+ååå
+  // Cached level, or 0 when absent (start point, constant, or broken loop edge).
+  static int level_of(const dict<SigBit, int> &cache, RTLIL::SigBit bit)
+  {
+    auto it = cache.find(bit);
+    return it == cache.end() ? 0 : it->second;
+  }
 
-  // Memoized backward level estimate. Sequential and undriven bits are start
-  // points; the active set breaks combinational loops.
+  // Combinational driver of `bit`, and the bits feeding it. Null at a start
+  // point (constant, undriven / multi-driven, or register output).
+  RTLIL::Cell *driver_inputs(RTLIL::SigBit bit, std::vector<RTLIL::SigBit> &ins)
+  {
+    ins.clear();
+    auto it = driver_map.find(bit);
+    RTLIL::Cell *drv = it == driver_map.end() ? nullptr : it->second;
+    if (drv == nullptr || drv->is_builtin_ff())
+      return nullptr;
+    for (auto &conn : drv->connections())
+      if (drv->input(conn.first))
+        for (auto &in_bit : sigmap(conn.second))
+          ins.push_back(in_bit);
+    return drv;
+  }
+
+  // Output bits of a cell, flattened across its output ports.
+  void cell_outputs(RTLIL::Cell *cell, std::vector<RTLIL::SigBit> &outs)
+  {
+    outs.clear();
+    for (auto &conn : cell->connections())
+      if (cell->output(conn.first))
+        for (auto &out_bit : sigmap(conn.second))
+          outs.push_back(out_bit);
+  }
+
+  // Levels from a start point up to this bit.
   int arrival_bit(RTLIL::SigBit bit)
   {
     if (bit.wire == nullptr)
       return 0;
-    auto it = arrival_cache.find(bit);
-    if (it != arrival_cache.end())
-      return it->second;
-    if (!arrival_active.insert(bit).second)
-      return 0;
-    int result = 0;
-    auto it_drv = driver_map.find(bit);
-    if (it_drv != driver_map.end() && it_drv->second != nullptr) {
-      RTLIL::Cell *drv = it_drv->second;
-      if (!drv->is_builtin_ff()) {
-        int max_in = 0;
-        for (auto &conn : drv->connections()) {
-          if (!drv->input(conn.first))
-            continue;
-          for (auto &in_bit : sigmap(conn.second))
-            max_in = std::max(max_in, arrival_bit(in_bit));
-        }
-        result = max_in + estimate_cell_delay(drv);
+    if (arrival_cache.count(bit))
+      return arrival_cache.at(bit);
+
+    std::vector<RTLIL::SigBit> stack{bit}, ins;
+    while (!stack.empty()) {
+      RTLIL::SigBit b = stack.back();
+      if (b.wire == nullptr || arrival_cache.count(b)) {
+        stack.pop_back();
+        continue;
       }
+
+      // Push unresolved inputs; skip actives (loop) and constants (never cached).
+      RTLIL::Cell *drv = driver_inputs(b, ins);
+      bool ready = true;
+      for (auto &in_bit : ins)
+        if (in_bit.wire != nullptr && !arrival_cache.count(in_bit) &&
+            !arrival_active.count(in_bit)) {
+          stack.push_back(in_bit);
+          ready = false;
+        }
+      if (!ready) {
+        arrival_active.insert(b);
+        continue; // leave b on the stack; neighbours are above it now
+      }
+
+      int latest = 0;
+      for (auto &in_bit : ins)
+        latest = std::max(latest, level_of(arrival_cache, in_bit));
+      arrival_cache[b] = drv == nullptr ? 0 : latest + estimate_cell_delay(drv);
+      arrival_active.erase(b);
+      stack.pop_back();
     }
-    arrival_active.erase(bit);
-    arrival_cache[bit] = result;
-    return result;
+    return arrival_cache.at(bit);
   }
 
   int arrival(const RTLIL::SigSpec &sig)
@@ -132,36 +175,58 @@ struct OptMuxPushWorker
     return t;
   }
 
-  // Mirror of arrival_bit walking forward: levels from this bit to the latest
-  // endpoint that reads it. Registers and unread bits end a path.
+  // Levels from this bit down to the latest endpoint that reads it.
   int depart_bit(RTLIL::SigBit bit)
   {
     if (bit.wire == nullptr)
       return 0;
-    auto it = depart_cache.find(bit);
-    if (it != depart_cache.end())
-      return it->second;
-    if (!depart_active.insert(bit).second)
-      return 0;
-    int result = 0;
-    auto it_cons = consumer_map.find(bit);
-    if (it_cons != consumer_map.end()) {
-      for (auto cons : it_cons->second) {
-        if (cons->is_builtin_ff())
-          continue;
-        int max_out = 0;
-        for (auto &conn : cons->connections()) {
-          if (!cons->output(conn.first))
-            continue;
-          for (auto &out_bit : sigmap(conn.second))
-            max_out = std::max(max_out, depart_bit(out_bit));
-        }
-        result = std::max(result, estimate_cell_delay(cons) + max_out);
+    if (depart_cache.count(bit))
+      return depart_cache.at(bit);
+
+    std::vector<RTLIL::SigBit> stack{bit}, outs;
+    while (!stack.empty()) {
+      RTLIL::SigBit b = stack.back();
+      if (b.wire == nullptr || depart_cache.count(b)) {
+        stack.pop_back();
+        continue;
       }
+
+      // Push unresolved fanout bits; registers end a path (no neighbours).
+      bool ready = true;
+      auto it_cons = consumer_map.find(b);
+      if (it_cons != consumer_map.end())
+        for (auto cons : it_cons->second) {
+          if (cons->is_builtin_ff())
+            continue;
+          cell_outputs(cons, outs);
+          for (auto &out_bit : outs)
+            if (out_bit.wire != nullptr && !depart_cache.count(out_bit) &&
+                !depart_active.count(out_bit)) {
+              stack.push_back(out_bit);
+              ready = false;
+            }
+        }
+      if (!ready) {
+        depart_active.insert(b);
+        continue;
+      }
+
+      int worst = 0;
+      if (it_cons != consumer_map.end())
+        for (auto cons : it_cons->second) {
+          if (cons->is_builtin_ff())
+            continue;
+          int latest = 0;
+          cell_outputs(cons, outs);
+          for (auto &out_bit : outs)
+            latest = std::max(latest, level_of(depart_cache, out_bit));
+          worst = std::max(worst, estimate_cell_delay(cons) + latest);
+        }
+      depart_cache[b] = worst;
+      depart_active.erase(b);
+      stack.pop_back();
     }
-    depart_active.erase(bit);
-    depart_cache[bit] = result;
-    return result;
+    return depart_cache.at(bit);
   }
 
   // Longest path through this signal, in the same unit-delay currency as the

--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -93,7 +93,7 @@ struct OptMuxPushWorker
       timing_guard(timing_guard), slack_margin(slack_margin), total_count(0)
   {
   }
-ååå
+
   // Cached level, or 0 when absent (start point, constant, or broken loop edge).
   static int level_of(const dict<SigBit, int> &cache, RTLIL::SigBit bit)
   {


### PR DESCRIPTION
## Summary
- Replace the recursive `arrival_bit` / `depart_bit` timing walk in `muxpush` with an explicit iterative stack traversal.
- Deep combinational cones (common under `-timing`) no longer blow the C stack while computing unit-delay arrival, departure, and module depth.
- Behavior of the delay heuristic and `-timing` / `-slack-margin` guards is unchanged; only the evaluation strategy moves from recursion to iteration.