### PR TITLE
peepopt_shiftpow2: carry the shifter's src onto the emitted $bmux

### DIFF
--- a/passes/opt/peepopt_shiftpow2.pmg
+++ b/passes/opt/peepopt_shiftpow2.pmg
@@ -80,7 +80,10 @@ code
 		}
 	}
 
-	module->addBmux(NEW_ID, bmux_a, sel, port(shift, \Y));
+	// `cell` is read by NEW_ID2_SUFFIX (kernel/yosys_common.h:324); name the $bmux after the
+	// shifter it replaces and carry its src over, since autoremove drops the only cell with one.
+	Cell *cell = shift;
+	module->addBmux(NEW_ID2_SUFFIX("bmux"), bmux_a, sel, port(shift, \Y), shift->get_src_attribute());
 	autoremove(shift);
 	accept;
 }

--- a/tests/various/peepopt.ys
+++ b/tests/various/peepopt.ys
@@ -215,6 +215,24 @@ select -assert-count 0 t:$shr
 
 ####################
 
+# shiftpow2: the $bmux inherits the src of the shifter, which autoremove deletes.
+# Without it the whole downstream cone loses its RTL attribution, since bmuxmap
+# and abc's node retention faithfully propagate the empty string.
+design -reset
+read_verilog <<EOT
+module peepopt_shiftpow2_src (input [63:0] D, input [2:0] S, output [7:0] Y);
+	assign Y = D >> (S*8);
+endmodule
+EOT
+
+prep -nokeepdc
+peepopt
+clean
+select -assert-count 1 t:$bmux
+select -assert-count 1 t:$bmux a:src=*:2.* %i
+
+####################
+
 # shiftpow2 must NOT fire for overlapping selections
 design -reset
 read_verilog <<EOT


### PR DESCRIPTION
## Summary

`peepopt`'s `shiftpow2` rule emitted its replacement `$bmux` with a bare `NEW_ID`, so `addBmux`'s `src` argument defaulted to `""`, and `autoremove(shift)` then deleted the only cell that carried one. Every pass downstream propagates that faithfully — `bmuxmap` copies the empty `src` onto each `$eq`/`$or`/`$reduce_or`/`$mux` it lowers to, and `abc`'s node retention pools it onto the mapped gates — so an entire logic cone can reach STA with no RTL attribution, showing up as `$auto$peepopt_pm.h:<line>:block_17$<n>`.

Every other peepopt pattern already forwards `src` (`peepopt_modshr_onehot`, `peepopt_shiftmul_left`, `peepopt_formal_clockgateff`, and `pmux2shiftx`, which is what hands `shiftpow2` its `$shiftx` in the first place); `shiftpow2` was the one gap.

- Pass `shift->get_src_attribute()` to `addBmux`.
- Name the `$bmux` after the shifter it replaces via `NEW_ID2_SUFFIX("bmux")`, matching the other Silimate patterns.

Found while chasing missing `src` attributes on a Preqorsor design whose mod-7 residue LUTs go `$pmux` -> `pmux2shiftx` -> `$shiftx` -> `shiftpow2` -> `$bmux`. Across every timing path in that run, path steps with an empty `verilog_src` went from 114/332 to 0/332, with `lol`/`clk`/`area` bit-identical — this is attribution-only, no QoR impact.

## Test plan

- [x] New case in `tests/various/peepopt.ys` asserting the emitted `$bmux` carries a `src` pointing at the RTL line. Verified non-vacuous: it fails with `selection contains 0 elements instead of the asserted 1` on a pre-fix build.
- [x] `tests/various/peepopt.ys` passes in full.
- [x] `tests/opt/opt_xor_fold.ys` passes — checked specifically because it documents that `shiftadd`/`shiftmul` and `shiftpow2` race on the same `$shiftx` in a way that depends on cell-name hash order, which the rename perturbs.
- [x] Preqorsor's shift/bmux/mod7/pow2 regressions (16 cases: `op_bmux`, `op_shift`, `customer_modshr`, `customer_shiftnetwork`, `customer_sshr_large`, `mt_shrs`, `qor_mod7_*`, `qor_pow2_*`) all pass.
- [ ] Full Preqorsor regression sweep (running).

Made with [Cursor](https://cursor.com)