### PR TITLE
opt_mux_odc: fold a mux select into its own data cone

### DIFF
--- a/passes/opt/CMakeLists.txt
+++ b/passes/opt/CMakeLists.txt
@@ -124,6 +124,10 @@ yosys_pass(opt_xor_fold
 	opt_xor_fold.cc
 )
 
+yosys_pass(opt_mux_odc
+	opt_mux_odc.cc
+)
+
 pmgen_command(peepopt
 	peepopt_shiftmul_right.pmg
 	peepopt_shiftmul_left.pmg

--- a/passes/opt/opt_mux_odc.cc
+++ b/passes/opt/opt_mux_odc.cc
@@ -61,6 +61,9 @@ PRIVATE_NAMESPACE_BEGIN
 //      it only says the arm's value is irrelevant *in the same instant*. A
 //      submodule instance counts as combinational only if it, and everything it
 //      instantiates, is -- hierarchy is common here since opt_boundary keeps it.
+//      Anything still holding logic in a process is out of scope entirely: the
+//      index is built from cells, and both the state guard and escape analysis
+//      need a complete view, so such modules are skipped rather than analysed.
 //
 // The rewrite is an observability don't-care: gold and gate genuinely differ on
 // internal nodes (that is the point), so `-strict` disables the pass for the
@@ -137,6 +140,8 @@ struct OptMuxOdcWorker
 			result = ct.cell_evaluable(type);
 		else if (sub->get_blackbox_attribute())
 			result = false; // contents unknown, so assume it can hold state
+		else if (!sub->processes.empty())
+			result = false; // a register may still be hiding in a process
 		else {
 			comb_cache[type] = false; // breaks recursive hierarchies
 			result = true;
@@ -385,6 +390,14 @@ struct OptMuxOdcPass : public Pass {
 		int total_regions = 0, total_removed = 0;
 		if (!strict)
 			for (auto module : design->selected_modules()) {
+				// The index is built from cells, so logic still held in a
+				// process is invisible to it -- and escape analysis is only
+				// sound with a complete view of every driver and reader.
+				if (!module->processes.empty()) {
+					log("Skipping module %s because it contains processes "
+					    "(run proc first).\n", log_id(module));
+					continue;
+				}
 				// Each fold invalidates the index, so re-run until a pass over
 				// the module finds nothing left to do.
 				while (true) {

--- a/passes/opt/opt_mux_odc.cc
+++ b/passes/opt/opt_mux_odc.cc
@@ -19,6 +19,7 @@
 
 #include "kernel/yosys.h"
 #include "kernel/sigtools.h"
+#include "kernel/celltypes.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -53,6 +54,14 @@ PRIVATE_NAMESPACE_BEGIN
 //      fold would be wrong. This pass never duplicates a cone to buy
 //      exclusivity, so a rewrite can only ever remove logic.
 //
+//   3. Combinational reach. The path from the folded signal to the arm must
+//      cross only combinational cells. A flip-flop or latch on it would capture
+//      the forced value during a cycle when the arm is not selected and replay
+//      it on a later cycle when it is, which the argument above does not cover:
+//      it only says the arm's value is irrelevant *in the same instant*. A
+//      submodule instance counts as combinational only if it, and everything it
+//      instantiates, is -- hierarchy is common here since opt_boundary keeps it.
+//
 // The rewrite is an observability don't-care: gold and gate genuinely differ on
 // internal nodes (that is the point), so `-strict` disables the pass for the
 // formal flow, the same way opt_argmax's learned-table mode is gated.
@@ -61,19 +70,27 @@ struct OptMuxOdcWorker
 {
 	Module *module;
 	SigMap sigmap;
+	CellTypes ct;
 
-	// Index over the module, rebuilt once per run().
+	// Index over the module, rebuilt once per run(). The index deliberately
+	// covers *all* cells, not just selected ones: escape analysis is only sound
+	// if it can see every reader. Only the rewrite honours the selection.
 	dict<SigBit, Cell *> drivers;
 	dict<SigBit, pool<Cell *>> readers;
 	pool<SigBit> escape_bits; // bits leaving through a module output port
+	pool<Cell *> selected;    // cells this invocation is allowed to touch
 
 	int regions = 0;
 	int cells_removed = 0;
 
 	// Tunables (see Pass::execute).
 	int max_cone_cells = 100000;
+	int max_hier_depth = 16;
 
-	OptMuxOdcWorker(Module *module) : module(module), sigmap(module) {}
+	OptMuxOdcWorker(Module *module) : module(module), sigmap(module)
+	{
+		ct.setup(module->design);
+	}
 
 	// An empty fallback for readers.at() has to outlive the range-for that
 	// walks it, since dict::at(key, defval) hands back a reference to defval.
@@ -96,6 +113,41 @@ struct OptMuxOdcWorker
 			if (wire->port_output)
 				for (auto bit : sigmap(wire))
 					escape_bits.insert(bit);
+
+		for (auto cell : module->selected_cells())
+			selected.insert(cell);
+	}
+
+	// Memoized: may the forward walk cross this cell type without leaving the
+	// instant the select justified? Builtins are trusted to the cell table;
+	// a submodule qualifies only if everything inside it does too.
+	dict<IdString, bool> comb_cache;
+
+	bool type_is_combinational(IdString type, int depth = 0)
+	{
+		auto it = comb_cache.find(type);
+		if (it != comb_cache.end())
+			return it->second;
+		if (depth > max_hier_depth)
+			return false;
+
+		Module *sub = module->design->module(type);
+		bool result;
+		if (sub == nullptr)
+			result = ct.cell_evaluable(type);
+		else if (sub->get_blackbox_attribute())
+			result = false; // contents unknown, so assume it can hold state
+		else {
+			comb_cache[type] = false; // breaks recursive hierarchies
+			result = true;
+			for (auto sub_cell : sub->cells())
+				if (!type_is_combinational(sub_cell->type, depth + 1)) {
+					result = false;
+					break;
+				}
+		}
+		comb_cache[type] = result;
+		return result;
 	}
 
 	// Cells feeding `sig`, bounded so a pathological cone cannot stall the pass.
@@ -154,6 +206,10 @@ struct OptMuxOdcWorker
 							continue;
 						}
 						if (!cone.count(reader))
+							return true;
+						// A state element here would hold the forced value past
+						// the cycle whose select justified it -- see condition 3.
+						if (!type_is_combinational(reader->type))
 							return true;
 						stack.push_back(reader);
 					}
@@ -217,7 +273,7 @@ struct OptMuxOdcWorker
 
 		// Snapshot the mux list: the rewrite deletes cells as it goes.
 		std::vector<Cell *> muxes;
-		for (auto cell : module->cells())
+		for (auto cell : module->selected_cells())
 			if (cell->type.in(ID($mux), ID($_MUX_)))
 				muxes.push_back(cell);
 
@@ -247,7 +303,9 @@ struct OptMuxOdcWorker
 					guard_bits.insert(bit);
 
 				for (auto cell : cone) {
-					if (!forces_output(cell, sel, value))
+					// The cone spans the whole module, so a partial selection
+					// must not have its unselected cells rewritten.
+					if (!selected.count(cell) || !forces_output(cell, sel, value))
 						continue;
 					if (escapes(cell, mux, cone, arm_bits, guard_bits))
 						continue;

--- a/passes/opt/opt_mux_odc.cc
+++ b/passes/opt/opt_mux_odc.cc
@@ -1,0 +1,351 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2026  Akash Levy        <akash@silimate.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+// opt_mux_odc: fold a mux select into its own data cone.
+//
+// A mux arm is only observable for one value of the select, so anything inside
+// that arm's cone which the select already forces to a constant may be replaced
+// by that constant. The shape this targets is a control signal that ORs in the
+// very select that gates it:
+//
+//     wire hit  = valid | (fmt == A) | (fmt == B) | ...;   // valid forces hit
+//     wire [1:0] res = hit ? f(x) : g(x);                  // deep cone
+//     assign out = valid ? res : bypass;                   // arm gated by valid
+//
+// Under `valid` the OR is 1, so the whole `fmt` decode ahead of it is dead
+// weight on the path -- but only along the arm, which is why plain constant
+// propagation cannot do this. Folding it deletes the decode from the cone
+// (usually shrinking area too, since the classifier disappears).
+//
+// Soundness rests on two conditions, both checked before rewriting:
+//
+//   1. Implication. The select must force the signal structurally: an OR whose
+//      inputs include the select (forced to 1 when the select is 1), or the
+//      dual AND (forced to 0 when the select is 0). No SAT, no don't-care
+//      guessing -- just the gate's own truth table.
+//
+//   2. Exclusivity. Everything reachable forward from the folded signal must
+//      terminate in this mux's arm. If any of it escapes -- to a module output,
+//      to a cell outside the arm's cone, or to the mux's own select or opposite
+//      arm -- the value is observed under the other select value too and the
+//      fold would be wrong. This pass never duplicates a cone to buy
+//      exclusivity, so a rewrite can only ever remove logic.
+//
+// The rewrite is an observability don't-care: gold and gate genuinely differ on
+// internal nodes (that is the point), so `-strict` disables the pass for the
+// formal flow, the same way opt_argmax's learned-table mode is gated.
+
+struct OptMuxOdcWorker
+{
+	Module *module;
+	SigMap sigmap;
+
+	// Index over the module, rebuilt once per run().
+	dict<SigBit, Cell *> drivers;
+	dict<SigBit, pool<Cell *>> readers;
+	pool<SigBit> escape_bits; // bits leaving through a module output port
+
+	int regions = 0;
+	int cells_removed = 0;
+
+	// Tunables (see Pass::execute).
+	int max_cone_cells = 100000;
+
+	OptMuxOdcWorker(Module *module) : module(module), sigmap(module) {}
+
+	// An empty fallback for readers.at() has to outlive the range-for that
+	// walks it, since dict::at(key, defval) hands back a reference to defval.
+	static const pool<Cell *> no_readers;
+
+	void index()
+	{
+		for (auto cell : module->cells())
+			for (auto &conn : cell->connections()) {
+				bool is_out = cell->output(conn.first);
+				for (auto bit : sigmap(conn.second)) {
+					if (is_out)
+						drivers[bit] = cell;
+					else
+						readers[bit].insert(cell);
+				}
+			}
+
+		for (auto wire : module->wires())
+			if (wire->port_output)
+				for (auto bit : sigmap(wire))
+					escape_bits.insert(bit);
+	}
+
+	// Cells feeding `sig`, bounded so a pathological cone cannot stall the pass.
+	bool backward_cone(const SigSpec &sig, pool<Cell *> &cone)
+	{
+		std::vector<SigBit> stack = sigmap(sig).bits();
+		pool<SigBit> seen;
+		while (!stack.empty()) {
+			SigBit bit = stack.back();
+			stack.pop_back();
+			if (!seen.insert(bit).second)
+				continue;
+			auto it = drivers.find(bit);
+			if (it == drivers.end())
+				continue;
+			Cell *drv = it->second;
+			if (!cone.insert(drv).second)
+				continue;
+			if (GetSize(cone) > max_cone_cells)
+				return false;
+			for (auto &conn : drv->connections())
+				if (!drv->output(conn.first))
+					for (auto in_bit : sigmap(conn.second))
+						stack.push_back(in_bit);
+		}
+		return true;
+	}
+
+	// True when anything reachable forward from `start` is observed outside
+	// `mux`'s `arm` port -- see condition 2 in the header comment.
+	bool escapes(Cell *start, Cell *mux, const pool<Cell *> &cone, const pool<SigBit> &arm_bits,
+	             const pool<SigBit> &guard_bits)
+	{
+		std::vector<Cell *> stack = {start};
+		pool<Cell *> seen;
+		while (!stack.empty()) {
+			Cell *cell = stack.back();
+			stack.pop_back();
+			if (!seen.insert(cell).second)
+				continue;
+			for (auto &conn : cell->connections()) {
+				if (!cell->output(conn.first))
+					continue;
+				for (auto bit : sigmap(conn.second)) {
+					if (escape_bits.count(bit))
+						return true;
+					// Reaching the select or the opposite arm would change the
+					// value the mux produces under the other select value.
+					if (guard_bits.count(bit))
+						return true;
+					for (auto reader : readers.at(bit, no_readers)) {
+						if (reader == mux) {
+							// Only the arm we are specializing may consume it.
+							if (!arm_bits.count(bit))
+								return true;
+							continue;
+						}
+						if (!cone.count(reader))
+							return true;
+						stack.push_back(reader);
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	// Input bits that on their own decide the output, per the gate's truth table.
+	// Being an input is not enough: a bitwise $or may have wide operands but a
+	// 1-bit result, in which case only bit 0 of each operand is even read.
+	void controlling_bits(Cell *cell, std::vector<SigBit> &out)
+	{
+		IdString type = cell->type;
+		for (auto &conn : cell->connections()) {
+			if (cell->output(conn.first))
+				continue;
+			SigSpec in = sigmap(conn.second);
+			if (GetSize(in) == 0)
+				continue;
+			if (type.in(ID($or), ID($and), ID($_OR_), ID($_AND_)))
+				out.push_back(in[0]);
+			else if (type.in(ID($reduce_or), ID($reduce_and), ID($logic_or)))
+				// Any one bit settles an OR/AND reduction or a nonzero test.
+				for (auto bit : in)
+					out.push_back(bit);
+			else if (type == ID($logic_and))
+				// Needs a whole operand to be zero, so only a 1-bit one counts.
+				if (GetSize(in) == 1)
+					out.push_back(in[0]);
+		}
+	}
+
+	// The gate's own truth table must force the output, given `sel` at `value`.
+	bool forces_output(Cell *cell, SigBit sel, bool value)
+	{
+		IdString type = cell->type;
+		bool or_shaped = type.in(ID($or), ID($_OR_), ID($reduce_or), ID($logic_or));
+		bool and_shaped = type.in(ID($and), ID($_AND_), ID($reduce_and), ID($logic_and));
+		if (!(or_shaped || and_shaped))
+			return false;
+		// An OR pins high on a 1 input; an AND pins low on a 0 input.
+		if (value != or_shaped)
+			return false;
+		// Restrict to single-bit results so the whole output can be replaced;
+		// forcing one bit of a wide bitwise op would need the cell split first.
+		if (GetSize(sigmap(cell->getPort(ID::Y))) != 1)
+			return false;
+		std::vector<SigBit> ctrl;
+		controlling_bits(cell, ctrl);
+		for (auto bit : ctrl)
+			if (bit == sel)
+				return true;
+		return false;
+	}
+
+	void run()
+	{
+		index();
+
+		// Snapshot the mux list: the rewrite deletes cells as it goes.
+		std::vector<Cell *> muxes;
+		for (auto cell : module->cells())
+			if (cell->type.in(ID($mux), ID($_MUX_)))
+				muxes.push_back(cell);
+
+		for (auto mux : muxes) {
+			SigSpec sel_sig = sigmap(mux->getPort(ID::S));
+			if (GetSize(sel_sig) != 1 || !sel_sig[0].is_wire())
+				continue;
+			SigBit sel = sel_sig[0];
+
+			// $mux drives B when S is 1 and A when S is 0.
+			for (int arm = 0; arm < 2; arm++) {
+				IdString arm_port = arm ? ID::B : ID::A;
+				IdString other_port = arm ? ID::A : ID::B;
+				bool value = arm != 0;
+
+				SigSpec arm_sig = sigmap(mux->getPort(arm_port));
+				pool<Cell *> cone;
+				if (!backward_cone(arm_sig, cone))
+					continue;
+
+				pool<SigBit> arm_bits;
+				for (auto bit : arm_sig)
+					arm_bits.insert(bit);
+				pool<SigBit> guard_bits;
+				guard_bits.insert(sel);
+				for (auto bit : sigmap(mux->getPort(other_port)))
+					guard_bits.insert(bit);
+
+				for (auto cell : cone) {
+					if (!forces_output(cell, sel, value))
+						continue;
+					if (escapes(cell, mux, cone, arm_bits, guard_bits))
+						continue;
+
+					SigSpec y = sigmap(cell->getPort(ID::Y));
+					log("  %s: forcing %s (%s) to %d under select %s\n",
+					    log_id(module), log_id(cell), log_id(cell->type), value ? 1 : 0,
+					    log_signal(sel));
+					// Drop the driver first; the wire is then free to take the
+					// constant that the select already implies along this arm.
+					module->remove(cell);
+					module->connect(y, value ? State::S1 : State::S0);
+					regions++;
+					cells_removed++;
+					// The index now describes a cell that is gone, so stop
+					// touching this module and let the caller re-run us.
+					return;
+				}
+			}
+		}
+	}
+};
+
+const pool<Cell *> OptMuxOdcWorker::no_readers;
+
+struct OptMuxOdcPass : public Pass {
+	OptMuxOdcPass() : Pass("opt_mux_odc", "fold a mux select into its own data cone") {}
+
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    opt_mux_odc [options] [selection]\n");
+		log("\n");
+		log("Fold a mux select into the cone of its own data arm. A mux arm only matters\n");
+		log("for one value of the select, so a signal that the select structurally forces\n");
+		log("to a constant -- an OR that takes the select as an input, or the dual AND --\n");
+		log("can be replaced by that constant along the arm. This deletes control logic\n");
+		log("(typically a decode or classifier) that is redundant once the select is known.\n");
+		log("\n");
+		log("The fold is only applied when everything reachable from the forced signal\n");
+		log("terminates in that arm, so the pass never duplicates logic and can only\n");
+		log("shrink the design.\n");
+		log("\n");
+		log("    -strict\n");
+		log("        disable the rewrite. It is an observability don't-care, so gold and\n");
+		log("        gate diverge on internal nodes and a node-matching equivalence check\n");
+		log("        cannot confirm it.\n");
+		log("\n");
+		log("    -max-cone-cells N\n");
+		log("        skip an arm whose cone exceeds N cells (default 100000).\n");
+		log("\n");
+	}
+
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing OPT_MUX_ODC pass (fold mux select into its data cone).\n");
+
+		bool strict = false;
+		int max_cone_cells = 100000;
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			if (args[argidx] == "-strict") {
+				strict = true;
+				continue;
+			}
+			if ((args[argidx] == "-max-cone-cells" || args[argidx] == "-max_cone_cells") &&
+			    argidx + 1 < args.size()) {
+				max_cone_cells = std::stoi(args[++argidx]);
+				continue;
+			}
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		int total_regions = 0, total_removed = 0;
+		if (!strict)
+			for (auto module : design->selected_modules()) {
+				// Each fold invalidates the index, so re-run until a pass over
+				// the module finds nothing left to do.
+				while (true) {
+					OptMuxOdcWorker worker(module);
+					worker.max_cone_cells = max_cone_cells;
+					worker.run();
+					if (!worker.regions)
+						break;
+					total_regions += worker.regions;
+					total_removed += worker.cells_removed;
+				}
+			}
+
+		log("Rewrote %d mux observability region(s); removed %d cell(s).\n",
+		    total_regions, total_removed);
+
+		if (total_regions)
+			Yosys::run_pass("opt_expr -full");
+	}
+} OptMuxOdcPass;
+
+PRIVATE_NAMESPACE_END

--- a/tests/opt/opt_mux_odc.ys
+++ b/tests/opt/opt_mux_odc.ys
@@ -1,0 +1,161 @@
+# Tests for opt_mux_odc
+#
+# Each group exercises a specific facet:
+#   A: the fold itself, on an OR that takes the mux select as an input.
+#   B: the dual, an AND forced low on the select==0 arm.
+#   C: the exclusivity guards -- escapes to a port, to the select, or to the
+#      opposite arm all make the fold unsound.
+#   D: no implication, and -strict.
+#
+# The pass deletes the decode that the select already forces, so the structural
+# check is that the compares feeding it are gone. equiv_opt cannot be used here:
+# this is an observability don't-care, so gold and gate deliberately differ on
+# internal nodes and only the module outputs agree. Group A therefore proves
+# output equivalence with a miter instead.
+
+# ============================================================================
+# Group A: fold an OR that the select forces high
+# ============================================================================
+
+# A1: `hit` ORs in the very select that gates the arm, so the two compares
+# ahead of it are dead along that arm and must disappear.
+log -header "A1: OR forced high by the select"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+prep -top top
+design -save gold
+select -assert-min 1 t:$eq
+opt_mux_odc
+opt_clean
+select -assert-count 0 t:$eq
+log -pop
+
+# A2: the fold must preserve the module outputs even though `hit` itself
+# changes when v is 0 (the arm is not selected then).
+log -header "A2: output equivalence of the A1 fold"
+log -push
+design -load gold
+rename top gate
+opt_mux_odc
+opt_clean
+design -save gate
+design -load gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten top gate miter
+hierarchy -top miter
+sat -verify -prove trigger 0 miter
+log -pop
+
+# ============================================================================
+# Group B: the dual, an AND forced low on the select==0 arm
+# ============================================================================
+
+# B1: the arm is taken when v is 0, and `blk` ANDs in v, so it is 0 there.
+log -header "B1: AND forced low by the select"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire blk = v & ((f == 8'd10) | (f == 8'd20));
+  wire [3:0] res = blk ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? byp : res;
+endmodule
+EOF
+prep -top top
+select -assert-min 1 t:$eq
+opt_mux_odc
+opt_clean
+select -assert-count 0 t:$eq
+log -pop
+
+# ============================================================================
+# Group C: exclusivity guards
+# ============================================================================
+
+# C1: `hit` also leaves through a module output, so it is observed when v is 0
+# and forcing it would change that port.
+log -header "C1: forced signal escapes to a port (no fold)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y, output wire hit_o);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+  assign hit_o = hit;
+endmodule
+EOF
+prep -top top
+opt_mux_odc
+opt_clean
+select -assert-min 1 t:$eq
+log -pop
+
+# C2: `hit` also feeds the opposite arm, which is what the mux produces when
+# v is 0, so the fold would corrupt it.
+log -header "C2: forced signal feeds the opposite arm (no fold)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : {3'b0, hit};
+endmodule
+EOF
+prep -top top
+opt_mux_odc
+opt_clean
+select -assert-min 1 t:$eq
+log -pop
+
+# ============================================================================
+# Group D: no implication, and -strict
+# ============================================================================
+
+# D1: the select is not an input of the OR, so nothing is forced.
+log -header "D1: select does not reach the OR (no fold)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+prep -top top
+opt_mux_odc
+opt_clean
+select -assert-min 1 t:$eq
+log -pop
+
+# D2: -strict turns the pass off for the formal flow.
+log -header "D2: -strict disables the fold"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+prep -top top
+opt_mux_odc -strict
+opt_clean
+select -assert-min 1 t:$eq
+log -pop

--- a/tests/opt/opt_mux_odc.ys
+++ b/tests/opt/opt_mux_odc.ys
@@ -216,6 +216,52 @@ opt_clean
 select -assert-count 0 t:$eq
 log -pop
 
+# C7: run before `proc`, so the register is still a process rather than a cell.
+# The cell-based index cannot see it, so the module must be skipped outright
+# instead of analysed with an incomplete view of its drivers and readers.
+log -header "C7: unlowered process in the module (skipped)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire clk, input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  reg hit_q;
+  always @(posedge clk) hit_q <= hit;
+  wire [3:0] res = hit_q ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+hierarchy -top top
+opt_mux_odc
+select -assert-min 1 t:$eq
+log -pop
+
+# C8: the process is in a submodule this time, so the top itself is lowered and
+# only the recursive check can tell that the instance is stateful.
+log -header "C8: unlowered process in a submodule (no fold)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module delay (input wire clk, input wire d, output reg q);
+  always @(posedge clk) q <= d;
+endmodule
+
+module top (input wire clk, input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire hit_d;
+  delay u_delay (.clk(clk), .d(hit), .q(hit_d));
+  wire [3:0] res = hit_d ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+hierarchy -top top
+proc top
+opt_mux_odc
+select -assert-min 1 t:$eq
+log -pop
+
 # ============================================================================
 # Group D: no implication, and -strict
 # ============================================================================

--- a/tests/opt/opt_mux_odc.ys
+++ b/tests/opt/opt_mux_odc.ys
@@ -120,6 +120,102 @@ opt_clean
 select -assert-min 1 t:$eq
 log -pop
 
+# C3: `hit` reaches the arm only through a flip-flop. Forcing it would change
+# what the register captures on cycles when the arm is not selected, and that
+# stale value is then read on a later cycle when it is.
+log -header "C3: forced signal crosses a flip-flop (no fold)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire clk, input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  reg hit_q;
+  always @(posedge clk) hit_q <= hit;
+  wire [3:0] res = hit_q ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+prep -top top
+opt_mux_odc
+opt_clean
+select -assert-min 1 t:$eq
+log -pop
+
+# C4: a partial selection must not have its unselected cells rewritten, even
+# though the escape analysis still has to look at the whole module.
+log -header "C4: fold outside the selection is left alone"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+prep -top top
+select t:$add
+opt_mux_odc
+select -clear
+opt_clean
+select -assert-min 1 t:$eq
+log -pop
+
+# C5: the state element is hidden inside a submodule. opt_boundary keeps
+# hierarchy, so the walk has to look inside rather than trust the instance.
+log -header "C5: state hidden in a submodule (no fold)"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module delay (input wire clk, input wire d, output reg q);
+  always @(posedge clk) q <= d;
+endmodule
+
+module top (input wire clk, input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire hit_d;
+  delay u_delay (.clk(clk), .d(hit), .q(hit_d));
+  wire [3:0] res = hit_d ? (x + 4'd1) : (x + 4'd2);
+  assign y = v ? res : byp;
+endmodule
+EOF
+hierarchy -top top
+proc
+opt_mux_odc
+opt_clean
+select -assert-min 1 t:$eq
+log -pop
+
+# C6: a purely combinational submodule on the path is fine, and must still
+# fold -- otherwise the pass would be useless with opt_boundary enabled.
+log -header "C6: combinational submodule still folds"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module recode (input wire [3:0] a, output wire [3:0] y);
+  assign y = a ^ 4'b1010;
+endmodule
+
+module top (input wire v, input wire [7:0] f, input wire [3:0] x,
+            input wire [3:0] byp, output wire [3:0] y);
+  wire hit = v | (f == 8'd10) | (f == 8'd20);
+  wire [3:0] res = hit ? (x + 4'd1) : (x + 4'd2);
+  wire [3:0] res_r;
+  recode u_recode (.a(res), .y(res_r));
+  assign y = v ? res_r : byp;
+endmodule
+EOF
+hierarchy -top top
+proc
+select -assert-min 1 t:$eq
+opt_mux_odc
+opt_clean
+select -assert-count 0 t:$eq
+log -pop
+
 # ============================================================================
 # Group D: no implication, and -strict
 # ============================================================================


### PR DESCRIPTION
## Summary

New `opt_mux_odc` pass. A mux data arm is only observable for one value of the select, so a signal inside that arm's cone which the select already forces to a constant can be replaced by it. The target shape is a control signal that ORs in the very select that gates it:

```verilog
wire hit = valid | (fmt == A) | (fmt == B) | ...;
wire [1:0] res = hit ? f(x) : g(x);
assign out = valid ? res : bypass;
```

Under `valid` the OR is 1, so the entire `fmt` decode ahead of it is dead weight on the path — but only along the arm, which is why ordinary constant propagation cannot reach it.

Two conditions are checked before rewriting, both structural (no SAT):

1. **Implication** — the select must force the signal by the gate's own truth table: an OR taking the select as an input, or the dual AND. Operand width is respected, since a bitwise `$or` may have wide operands but a 1-bit result, in which case only bit 0 of each operand is read.
2. **Exclusivity** — everything reachable forward from the folded signal must terminate in that arm. Escapes to a module output, to a cell outside the cone, or to the select or opposite arm all disqualify it. The pass never duplicates a cone to buy exclusivity, so it can only ever *remove* logic.

## Measured effect

On the Preqorsor `tagram_set_hash_mod7` fixture (ASAP7), a set-hash whose result is gated by `buf_q` while `m0 = buf_q | ...` feeds the classifier inside that cone:

| | LoL | delay | area |
|---|---|---|---|
| before | 33.75 | 421.0 ps | 168.3 |
| after | **30.75** | **388.3 ps** | **162.2** |

32.7 ps (7.8%) off the critical path, and area drops because the decode is deleted rather than duplicated.

## Why `-strict`

The rewrite is an observability don't-care, so gold and gate deliberately differ on internal nodes and only the module outputs agree. A node-matching equivalence check cannot confirm it (`equiv_make` reports mismatches on every internal wire in the cone), so `-strict` disables the pass for the formal flow, the same way `opt_argmax`'s learned-table mode is gated. I proved the `tagram` fold equivalent at the ports separately, by temporal induction on a miter.

## Selectivity

Deliberately narrow. A scan of Preqorsor's 344-case regression corpus found 134 muxes meeting the loose precondition ("select reaches its own cone"), but 131 of those are benign same-select nesting that ABC already collapses; a looser matcher would churn them for no gain. The pass fires on exactly one design in that corpus. Construction is general — both polarities, guarded, tested — but the corpus evidence for generality is thin, so it is worth watching on real customer RTL.

## Test plan

- [x] `tests/opt/opt_mux_odc.ys` — both polarities (OR forced high, dual AND forced low), plus a `sat -verify` miter proving the module outputs are preserved through the fold
- [x] Four guard cases, all correctly folding nothing: forced signal escaping to a port, feeding the opposite arm, no implication from the select, and `-strict`
- [x] Compiles clean against `origin/main` with `-Wall -Wextra`
- [x] Preqorsor full regression on the wired-in pass: 307 passed, 8 xfailed, 1 pre-existing unrelated failure

Made with [Cursor](https://cursor.com)