### PR TITLE
sim: add -missing-input-warn for input ports absent from the trace

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -3307,7 +3307,8 @@ struct SimPass : public Pass {
 		log("\n");
 		log("    -missing-input-warn\n");
 		log("        downgrade input ports missing from the FST/VCD to warnings, leaving them\n");
-		log("        undriven instead of aborting the replay\n");
+		log("        undriven instead of aborting the replay. Missing inputs remain X, so\n");
+		log("        downstream activity and derived power estimates can be underestimated.\n");
 		log("\n");
 		log("    -width <integer>\n");
 		log("        cycle width in generated simulation output (must be divisible by 2).\n");

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -111,6 +111,9 @@ struct DisplayOutput {
 	{ }
 };
 
+// SILIMATE: cap on how many missing FST inputs get named individually under -missing-input-warn
+static const int MAX_MISSING_INPUT_WARNINGS = 20;
+
 struct SimShared
 {
 	bool debug = false;
@@ -140,6 +143,10 @@ struct SimShared
 	bool initstate = true;
 	bool undriven_check = true;
 	bool undriven_warning = false;
+	// SILIMATE: -missing-input-warn keeps input ports that have no FST signal undriven instead of
+	// aborting; only the first MAX_MISSING_INPUT_WARNINGS of them are named to bound log size.
+	bool missing_input_warning = false;
+	int missing_inputs = 0;
 	bool blackbox_children = false;
 	pool<IdString> instance_root_modules;
 	double clk_period_override = 0.0;
@@ -1758,6 +1765,17 @@ struct SimWorker : SimShared
 		write_output_files();
 	}
 
+	// SILIMATE: an input port with no matching FST signal is fatal by default (its value would be
+	// unknown for the whole replay); -missing-input-warn leaves it undriven and keeps going.
+	void report_missing_fst_input(const std::string &path, Module *mod)
+	{
+		if (!missing_input_warning)
+			log_error("Can't find port '%s' on module '%s' in FST. Use -missing-input-warn to leave it undriven and continue.\n",
+					path.c_str(), log_id(mod));
+		if (++missing_inputs <= MAX_MISSING_INPUT_WARNINGS)
+			log_warning("Can't find port '%s' on module '%s' in FST, leaving it undriven.\n", path.c_str(), log_id(mod));
+	}
+
 	void run_cosim_fst(Module *topmod, int numcycles, int log_interval)
 	{
 		log_assert(tops.empty());
@@ -1783,8 +1801,8 @@ struct SimWorker : SimShared
 					if (!wire->port_input) continue;
 					fstHandle id = fst->getHandle(iscope + "." + wire->name.unescape());
 					if (id == 0) {
-						log_error("Can't find port '%s' on module '%s' in FST.\n",
-							iscope + "." + wire->name.unescape(), log_id(m));
+						report_missing_fst_input(iscope + "." + wire->name.unescape(), m);
+						continue;
 					}
 					t->fst_inputs[wire] = id;
 				}
@@ -1834,18 +1852,20 @@ struct SimWorker : SimShared
 				// Populate fst_inputs for input ports
 				if (wire->port_input) {
 					fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(wire->name));
-					if (id != 0) {
-						// Case of a regular wire/reg
+					if (id != 0)
 						top->fst_inputs[wire] = id;
-					} else {
-						// Not found
-						log_error("Unable to find required '%s' signal in file\n",(scope + "." + RTLIL::unescape_id(wire->name)));
-					}
+					else
+						report_missing_fst_input(scope + "." + RTLIL::unescape_id(wire->name), topmod);
 				}
 			}
 
 			top->addAdditionalInputs();
 		}
+
+		// SILIMATE: one line for the tail of the missing-input list that was not named above
+		if (missing_inputs > MAX_MISSING_INPUT_WARNINGS)
+			log_warning("%d further input port(s) missing from the FST are left undriven.\n",
+					missing_inputs - MAX_MISSING_INPUT_WARNINGS);
 
 		register_signals();
 		top->addAdditionalInputs();
@@ -3285,6 +3305,10 @@ struct SimPass : public Pass {
 		log("    -undriven-warn\n");
 		log("        downgrade undriven-signal replay errors to warnings\n");
 		log("\n");
+		log("    -missing-input-warn\n");
+		log("        downgrade input ports missing from the FST/VCD to warnings, leaving them\n");
+		log("        undriven instead of aborting the replay\n");
+		log("\n");
 		log("    -width <integer>\n");
 		log("        cycle width in generated simulation output (must be divisible by 2).\n");
 		log("\n");
@@ -3541,6 +3565,10 @@ struct SimPass : public Pass {
 			}
 			if (args[argidx] == "-undriven-warn") {
 				worker.undriven_warning = true;
+				continue;
+			}
+			if (args[argidx] == "-missing-input-warn") {
+				worker.missing_input_warning = true;
 				continue;
 			}
 			if (args[argidx] == "-x") {

--- a/tests/sim/missing_input.v
+++ b/tests/sim/missing_input.v
@@ -1,0 +1,7 @@
+module missing_input (
+	input wire a,
+	input wire b,
+	output wire out
+);
+	assign out = a & b;
+endmodule

--- a/tests/sim/missing_input.vcd
+++ b/tests/sim/missing_input.vcd
@@ -1,0 +1,12 @@
+$version Yosys $end
+$scope module missing_input $end
+$var wire 1 ! a $end
+$var wire 1 " out $end
+$upscope $end
+$enddefinitions $end
+#0
+b0 !
+b0 "
+#10
+b1 !
+b0 "

--- a/tests/sim/missing_input.ys
+++ b/tests/sim/missing_input.ys
@@ -1,0 +1,6 @@
+read_verilog missing_input.v
+prep -top missing_input
+
+# Input port `b` is absent from the trace, which is fatal by default
+logger -expect error "Can't find port 'missing_input.b' on module 'missing_input' in FST" 1
+sim -r missing_input.vcd -scope missing_input -q

--- a/tests/sim/missing_input_instance_warn.ys
+++ b/tests/sim/missing_input_instance_warn.ys
@@ -1,0 +1,6 @@
+read_verilog missing_input.v
+prep -top missing_input
+
+# Same downgrade on the multi-root -instance replay path
+logger -expect warning "Can't find port 'missing_input.b' on module 'missing_input' in FST" 1
+sim -r missing_input.vcd -instance missing_input:missing_input -q -missing-input-warn

--- a/tests/sim/missing_input_warn.ys
+++ b/tests/sim/missing_input_warn.ys
@@ -1,0 +1,6 @@
+read_verilog missing_input.v
+prep -top missing_input
+
+# -missing-input-warn leaves the absent port `b` undriven instead of aborting the replay
+logger -expect warning "Can't find port 'missing_input.b' on module 'missing_input' in FST" 1
+sim -r missing_input.vcd -scope missing_input -q -missing-input-warn


### PR DESCRIPTION
## Summary

When an input port of a replayed module has no matching signal in the FST/VCD, `sim` aborts. That is the right default (the port's value is unknown for the entire replay), but it makes a port-name mismatch painful to triage: the run dies on the first offender, so you never learn how many there are or what the pattern is.

`-missing-input-warn` downgrades it to a warning and leaves the port undriven instead, on both the single-root path and the multi-root `-instance` path. Only the first 20 missing ports are named individually, with a one-line summary for the rest, so a wholesale naming mismatch on a large design doesn't flood the log.

The default error message now points at the new flag, and the single-root path's `Unable to find required '%s' signal in file` is folded into the same wording as the multi-root path.

The caveat is real and belongs in the flag's description: an undriven port sits at X, so its fanout cone records no toggles and any activity/power derived from it is underestimated. This is a triage switch, not a way to get numbers out of a mismatched trace.

## Test plan

- [x] `tests/sim/missing_input.ys` — default behavior still errors, naming the port.
- [x] `tests/sim/missing_input_warn.ys` — single-root path warns and completes.
- [x] `tests/sim/missing_input_instance_warn.ys` — multi-root `-instance` path warns and completes.
- [x] Existing `undriven_replay{,_warn,_nocheck}.ys` still pass; the missing port does not double-report through the undriven check.
- [x] Manually confirmed a replay with a missing input completes and writes an activity VCD, with the missing port and its cone at X.

Made with [Cursor](https://cursor.com)