### PR TITLE
muxpush: distribute compares over a chain of muxes

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -274,6 +274,36 @@ struct OptMuxPushWorker
     return false;
   }
 
+  // Worst leaf/select arrival and level count of a chain or tree of muxes.
+  struct MuxTree { int leaf_arrival = 0; int sel_arrival = 0; int depth = 0; };
+
+  // Bounded so a deep mux tree cannot make the guard quadratic.
+  static const int max_push_depth = 8;
+
+  // Recurse only where a push would really be allowed, so the estimate matches
+  // what the iteration can actually reach; otherwise stop and treat sig as a leaf.
+  MuxTree mux_tree_stats(const RTLIL::SigSpec &sig, int budget)
+  {
+    MuxTree t;
+    RTLIL::Cell *m = nullptr;
+    RTLIL::SigSpec arm_a, arm_b;
+    if (budget > 0 && mux_drives_sig(sig, m) && design->selected(module, m) &&
+        !m->get_bool_attribute(ID::keep) &&
+        !sig_has_keep(sigmap(m->getPort(ID::Y))) &&
+        fanout_within_limit(sigmap(m->getPort(ID::Y))) &&
+        slice_arms(m, sigmap(m->getPort(ID::Y)), sig, arm_a, arm_b)) {
+      MuxTree a = mux_tree_stats(sigmap(arm_a), budget - 1);
+      MuxTree b = mux_tree_stats(sigmap(arm_b), budget - 1);
+      t.leaf_arrival = std::max(a.leaf_arrival, b.leaf_arrival);
+      t.sel_arrival = std::max(std::max(a.sel_arrival, b.sel_arrival),
+                               arrival(m->getPort(ID::S)));
+      t.depth = std::max(a.depth, b.depth) + 1;
+      return t;
+    }
+    t.leaf_arrival = arrival(sig);
+    return t;
+  }
+
   // Pushing pays when the select is the mux's late input: the operators then
   // evaluate on the early arms in parallel with the select instead of queueing
   // behind it. Otherwise it is pure area for no depth.
@@ -298,9 +328,12 @@ struct OptMuxPushWorker
       return true;
     }
 
-    int d_a = arrival(arm_a);
-    int d_b = arrival(arm_b);
-    int d_s = arrival(mux_cell->getPort(ID::S));
+    // A nested ternary builds a chain of muxes on one operand. Pushing one
+    // level is break-even there -- the operator still queues behind the rest of
+    // the chain -- so weigh the push against the fully pushed tree, which is
+    // where the operator finally sees only leaf arrivals. Judging a single level
+    // rejects the whole chain and the win is never reached.
+    MuxTree tree = mux_tree_stats(sigmap(cell->getPort(port)), max_push_depth);
     int d_mux = estimate_cell_delay(mux_cell);
     int d_op = estimate_cell_delay(cell);
 
@@ -311,11 +344,14 @@ struct OptMuxPushWorker
       others = std::max(others, arrival(conn.second));
     }
 
-    int before = std::max(std::max(std::max(d_a, d_b), d_s) + d_mux, others) + d_op;
-    int after = std::max(std::max(std::max(d_a, d_b), others) + d_op, d_s) + d_mux;
-    log_debug("    %s %s port %s: dA=%d dB=%d dS=%d before=%d after=%d slack=%d\n",
-        log_id(cell->type), log_id(cell->name), log_id(port), d_a, d_b, d_s,
-        before, after, slack);
+    // For a lone mux this is exactly the single-level estimate, since then
+    // leaf_arrival is max(dA,dB), sel_arrival is dS and depth is 1.
+    int before = std::max(arrival(cell->getPort(port)), others) + d_op;
+    int after = std::max(std::max(tree.leaf_arrival, others) + d_op,
+                         tree.sel_arrival) + tree.depth * d_mux;
+    log_debug("    %s %s port %s: leaf=%d sel=%d levels=%d before=%d after=%d slack=%d\n",
+        log_id(cell->type), log_id(cell->name), log_id(port), tree.leaf_arrival,
+        tree.sel_arrival, tree.depth, before, after, slack);
     return after < before;
   }
 
@@ -381,9 +417,12 @@ struct OptMuxPushWorker
   {
     mux_cell = nullptr;
     for (auto &bit : sig) {
+      // Zero/sign-extension padding leaves constant bits in the operand (e.g.
+      // $lt A = { 3'000, \w_floor }). They are the same in both arms, so
+      // slice_arms passes them through and the push stays exact.
       if (bit.wire == nullptr)
-        return false;
-      // Require a single consistent driver for all bits in the SigSpec
+        continue;
+      // Require a single consistent driver for all variable bits in the SigSpec
       auto it_drv = driver_map.find(bit);
       if (it_drv == driver_map.end() || it_drv->second == nullptr)
         return false;
@@ -425,8 +464,15 @@ struct OptMuxPushWorker
     arm_b = RTLIL::SigSpec();
     for (auto &bit : in_sig) {
       auto it = pos.find(bit);
-      if (it == pos.end())
-        return false;
+      if (it == pos.end()) {
+        // Only extension padding may sit outside the mux output; a variable bit
+        // from another driver means this operand is not a view of the mux.
+        if (bit.wire != nullptr)
+          return false;
+        arm_a.append(bit);
+        arm_b.append(bit);
+        continue;
+      }
       arm_a.append(mux_a[it->second]);
       arm_b.append(mux_b[it->second]);
     }

--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -274,40 +274,35 @@ struct OptMuxPushWorker
     return false;
   }
 
-  // Worst leaf/select arrival and level count of a chain or tree of muxes.
-  struct MuxTree { int leaf_arrival = 0; int sel_arrival = 0; int depth = 0; };
-
-  // Bounded so a deep mux tree cannot make the guard quadratic.
+  // The walk below forks at every mux, so bound it: a deep tree would otherwise
+  // cost the guard 2^depth visits.
   static const int max_push_depth = 8;
 
-  // Recurse only where a push would really be allowed, so the estimate matches
-  // what the iteration can actually reach; otherwise stop and treat sig as a leaf.
-  MuxTree mux_tree_stats(const RTLIL::SigSpec &sig, int budget)
+  // Arrival out of the fully pushed tree: a copy of the operator lands on every
+  // leaf and the muxes restack above it, so each path is charged only the levels
+  // it really crosses -- an unbalanced tree must not pay its latest arm and its
+  // deepest arm at once. Recurse just where a push would be allowed, so the
+  // estimate matches what the iteration can reach; elsewhere the operator reads
+  // sig as it stands.
+  int pushed_arrival(const RTLIL::SigSpec &sig, int d_op, int others, int budget)
   {
-    MuxTree t;
     RTLIL::Cell *m = nullptr;
     RTLIL::SigSpec arm_a, arm_b;
     if (budget > 0 && mux_drives_sig(sig, m) && design->selected(module, m) &&
         !m->get_bool_attribute(ID::keep) &&
         !sig_has_keep(sigmap(m->getPort(ID::Y))) &&
         fanout_within_limit(sigmap(m->getPort(ID::Y))) &&
-        slice_arms(m, sigmap(m->getPort(ID::Y)), sig, arm_a, arm_b)) {
-      MuxTree a = mux_tree_stats(sigmap(arm_a), budget - 1);
-      MuxTree b = mux_tree_stats(sigmap(arm_b), budget - 1);
-      t.leaf_arrival = std::max(a.leaf_arrival, b.leaf_arrival);
-      t.sel_arrival = std::max(std::max(a.sel_arrival, b.sel_arrival),
-                               arrival(m->getPort(ID::S)));
-      t.depth = std::max(a.depth, b.depth) + 1;
-      return t;
-    }
-    t.leaf_arrival = arrival(sig);
-    return t;
+        slice_arms(m, sigmap(m->getPort(ID::Y)), sig, arm_a, arm_b))
+      return std::max({pushed_arrival(sigmap(arm_a), d_op, others, budget - 1),
+                       pushed_arrival(sigmap(arm_b), d_op, others, budget - 1),
+                       arrival(m->getPort(ID::S))}) + estimate_cell_delay(m);
+    return std::max(arrival(sig), others) + d_op;
   }
 
   // Pushing pays when the select is the mux's late input: the operators then
   // evaluate on the early arms in parallel with the select instead of queueing
   // behind it. Otherwise it is pure area for no depth.
-  bool should_push(RTLIL::Cell *cell, IdString port, RTLIL::Cell *mux_cell,
+  bool should_push(RTLIL::Cell *cell, IdString port,
       const RTLIL::SigSpec &arm_a, const RTLIL::SigSpec &arm_b)
   {
     if (!timing_guard)
@@ -328,13 +323,6 @@ struct OptMuxPushWorker
       return true;
     }
 
-    // A nested ternary builds a chain of muxes on one operand. Pushing one
-    // level is break-even there -- the operator still queues behind the rest of
-    // the chain -- so weigh the push against the fully pushed tree, which is
-    // where the operator finally sees only leaf arrivals. Judging a single level
-    // rejects the whole chain and the win is never reached.
-    MuxTree tree = mux_tree_stats(sigmap(cell->getPort(port)), max_push_depth);
-    int d_mux = estimate_cell_delay(mux_cell);
     int d_op = estimate_cell_delay(cell);
 
     int others = 0;
@@ -344,14 +332,16 @@ struct OptMuxPushWorker
       others = std::max(others, arrival(conn.second));
     }
 
-    // For a lone mux this is exactly the single-level estimate, since then
-    // leaf_arrival is max(dA,dB), sel_arrival is dS and depth is 1.
+    // A nested ternary builds a chain of muxes on one operand. Pushing one level
+    // is break-even there -- the operator still queues behind the rest of the
+    // chain -- so weigh the push against the fully pushed tree, which is where
+    // the operator finally sees only leaf arrivals. Judging a single level
+    // rejects the whole chain and the win is never reached. For a lone mux this
+    // reduces exactly to the single-level estimate.
     int before = std::max(arrival(cell->getPort(port)), others) + d_op;
-    int after = std::max(std::max(tree.leaf_arrival, others) + d_op,
-                         tree.sel_arrival) + tree.depth * d_mux;
-    log_debug("    %s %s port %s: leaf=%d sel=%d levels=%d before=%d after=%d slack=%d\n",
-        log_id(cell->type), log_id(cell->name), log_id(port), tree.leaf_arrival,
-        tree.sel_arrival, tree.depth, before, after, slack);
+    int after = pushed_arrival(sigmap(cell->getPort(port)), d_op, others, max_push_depth);
+    log_debug("    %s %s port %s: others=%d before=%d after=%d slack=%d\n",
+        log_id(cell->type), log_id(cell->name), log_id(port), others, before, after, slack);
     return after < before;
   }
 
@@ -548,7 +538,7 @@ struct OptMuxPushWorker
             continue;
           if (!fanout_within_limit(mux_out))
             continue;
-          if (!should_push(cell, it.first, mux_cell, arm_a, arm_b))
+          if (!should_push(cell, it.first, arm_a, arm_b))
             continue;
 
           // Only push one mux per operator per iteration

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -457,6 +457,47 @@ design -reset
 log -pop
 
 
+log -header "-timing: an unbalanced tree pays only the levels each path crosses"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [7:0] g_lo,
+  input wire [7:0] g_hi,
+  input wire [4:0] f1,
+  input wire [4:0] f2,
+  input wire [7:0] w,
+  output wire y
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire [7:0] gp = g_lo * g_hi;
+  wire s1 = sp[3];
+  wire s2 = sp[4];
+  wire [4:0] f = s2 ? gp[4:0] : (s1 ? f1 : f2);
+  assign y = (w > {3'b0, f});
+endmodule
+EOF
+proc
+check -assert
+
+# The two arms of the outer mux are lopsided: one is a late multiply one level
+# up, the other a second mux over early inputs two levels up. Charging the
+# latest arrival and the deepest arm to one path prices the late arm as if it
+# crossed both muxes, which reads as break-even and declines the tree. Each path
+# pays only the levels it crosses, so the late arm is one mux short of that and
+# the push is worth a level.
+equiv_opt -assert muxpush -limit 1 -types $gt -timing
+design -load postopt
+select -set cmp_fanin t:$gt %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 0 @cmp_fanin @mux_cells %i
+
+design -reset
+log -pop
+
+
 log -header "-slack-margin rejects a negative allowance (ends the script, keep last)"
 log -push
 design -reset

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -379,6 +379,84 @@ design -reset
 log -pop
 
 
+log -header "-timing: a compare distributes over a chain of muxes"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [4:0] f0,
+  input wire [4:0] f1,
+  input wire [4:0] f2,
+  input wire [7:0] w,
+  output wire y
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire s1 = sp[3];
+  wire s2 = sp[4];
+  wire [4:0] f = s2 ? f0 : (s1 ? f1 : f2);
+  assign y = (w > {3'b0, f});
+endmodule
+EOF
+proc
+check -assert
+
+# Two things kept this candidate off the floor. The compare reads f zero-extended
+# to 8 bits, so its operand carries constant padding the mux does not drive; the
+# padding is the same in both arms, so projecting it through keeps the push exact.
+# And both selects arrive late behind the multiply while every arm is a module
+# input, which makes one level of push exactly break-even -- the compare still
+# queues behind the rest of the chain -- so a single-level estimate declines the
+# first step and the chain is never entered. Weighed as a whole tree it saves the
+# compare's own level.
+equiv_opt -assert muxpush -limit 1 -types $gt -timing
+design -load postopt
+select -set cmp_fanin t:$gt %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 0 @cmp_fanin @mux_cells %i
+
+design -reset
+log -pop
+
+
+log -header "Negative case: a variable bit outside the mux output blocks the push"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [4:0] f0,
+  input wire [4:0] f1,
+  input wire [2:0] hi,
+  input wire [7:0] w,
+  output wire y
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire s = sp[3];
+  wire [4:0] f = s ? f0 : f1;
+  assign y = (w > {hi, f});
+endmodule
+EOF
+proc
+check -assert
+
+# Same shape as above, except the operand's upper bits are a port instead of
+# constant padding. Only extension padding may sit outside the mux output: hi is
+# not a view of either arm, so speculating the compare on the arms alone would
+# drop it. Tolerating any bit the mux does not drive, rather than constants
+# only, silently rewrites this to the wrong function.
+equiv_opt -assert muxpush -limit 1 -types $gt -timing
+design -load postopt
+select -set cmp_fanin t:$gt %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 1 @cmp_fanin @mux_cells %i
+
+design -reset
+log -pop
+
+
 log -header "-slack-margin rejects a negative allowance (ends the script, keep last)"
 log -push
 design -reset


### PR DESCRIPTION
## Summary

Lets `muxpush -timing` speculate a comparison over a chain of muxes. Two
independent things kept comparisons off the candidate list:

- **Constant padding rejected the operand.** A compare reads its operand
  zero-extended (`$gt B = {3'b000, \f}`), and `mux_drives_sig` refused any
  operand containing bits the mux does not drive. The padding is identical in
  both arms, so `slice_arms` can project it through and the push stays exact.
  Only constant bits are tolerated; a variable bit from another driver still
  refuses, since speculating on the arms alone would change the function.
- **The profitability estimate judged one mux at a time.** On a nested ternary
  that is exactly break-even, because the operator still queues behind the rest
  of the chain, so the guard declined the first step and the chain was never
  entered. `should_push` now weighs the push against the fully pushed tree:
  `pushed_arrival` walks it and returns the arrival out of the pushed cone, with
  the operator on every leaf and the muxes restacked above it, so each path is
  charged only the levels it crosses and an unbalanced tree does not pay its
  latest arm and its deepest arm at once. It recurses only where a push would
  actually be allowed, so the estimate matches what the iteration can reach, and
  it forks at every mux, so it is bounded at 8 levels to cap the walk at
  `2^depth` visits. For a single mux it reduces to the old formula exactly.

Comparisons pay for this where wide adds do not: the duplicated operator is one
bit wide, and the mux feeding it usually also drives the data path, so it
survives the push rather than being deleted.

## Test plan

- [x] `tests/silimate/mux_push.ys` gains a positive group (padded compare over a
      two-level chain with late selects and early arms) and a negative group (a
      port, not constant padding, in the operand's upper bits must refuse).
      Both use `equiv_opt -assert`.
- [x] The new positive group fails on `main` — 0 pushes, and the assertion
      reports 2 muxes still in the compare's fanin — so it guards this change.
- [x] Existing groups in that file are unchanged and still pass.
- [x] Downstream: a controlled A/B over 131 comparison-heavy Preqorsor
      regressions, both arms built from the same commit, gives 5 improved,
      0 regressed, 117 identical. Best cases drop 4.0-8.75 levels of logic.
- [x] Equivalence checked in-flow with `equiv_opt -assert` on the improved
      designs; the compare-push step SAT-proves clean (131 `$equiv` cells).
- [x] No runtime cost: 70s vs 67s on the 40k-deep `mux_push_segfault` chain,
      despite that run doing an extra push invocation.
- [x] A third group covers an unbalanced tree — a late multiply one mux below
      the compare beside a deeper early arm — which the first cut of the
      estimate declined as break-even. Across 40 randomly generated mux trees
      feeding a compare, the path-exact estimate optimizes 8 that were declined
      and regresses none, all `equiv_opt -assert` clean.
- [x] The guard is free: `main` and both commits here run a 4095-mux tree in the
      same 0.28s, since the walk happens once per candidate that survives the
      slack filter.

Made with [Cursor](https://cursor.com)
