### PR TITLE
opt_mux_odc: find fold candidates via the select's fanout

### DIFF
--- a/passes/opt/opt_mux_odc.cc
+++ b/passes/opt/opt_mux_odc.cc
@@ -294,6 +294,20 @@ struct OptMuxOdcWorker
 				IdString other_port = arm ? ID::A : ID::B;
 				bool value = arm != 0;
 
+				// A cell can only be forced by the select if the select is one of
+				// its own inputs, so the candidates come straight off the index.
+				// Searching the arm's cone for them instead would cost a walk per
+				// mux, which dominates the run on a large design that folds
+				// nothing -- the common case by far.
+				std::vector<Cell *> candidates;
+				for (auto reader : readers.at(sel, no_readers))
+					// The cone spans the whole module, so a partial selection
+					// must not have its unselected cells rewritten.
+					if (selected.count(reader) && forces_output(reader, sel, value))
+						candidates.push_back(reader);
+				if (candidates.empty())
+					continue;
+
 				SigSpec arm_sig = sigmap(mux->getPort(arm_port));
 				pool<Cell *> cone;
 				if (!backward_cone(arm_sig, cone))
@@ -307,10 +321,10 @@ struct OptMuxOdcWorker
 				for (auto bit : sigmap(mux->getPort(other_port)))
 					guard_bits.insert(bit);
 
-				for (auto cell : cone) {
-					// The cone spans the whole module, so a partial selection
-					// must not have its unselected cells rewritten.
-					if (!selected.count(cell) || !forces_output(cell, sel, value))
+				for (auto cell : candidates) {
+					// Only a cell the arm actually depends on is unobservable
+					// when the select takes the other value.
+					if (!cone.count(cell))
 						continue;
 					if (escapes(cell, mux, cone, arm_bits, guard_bits))
 						continue;


### PR DESCRIPTION
## Summary

Follow-up to #248. The pass was walking each mux arm's backward cone to find fold
candidates, but `forces_output()` can only hold for a cell that takes the select as one of
its own inputs — so the walk was rediscovering cells the reader index already points at.

The cone walk ran per mux, per arm, unconditionally, which made the pass cost
muxes x cone-size on designs that fold nothing. That is every design in the corpus except
`qor_tagram_set_hash_mod7`.

This enumerates candidates from the select's fanout instead, and only walks the cone once a
candidate exists, to confirm the arm actually depends on it. The candidate set is
identical — only the direction of the search changes.

## Measurements

| design | before | after |
|---|---|---|
| `customer_veer_eh2` (0 folds) | 13.0s | 2.0s |
| synthetic, 400 folding muxes | 2.60s | 0.76s |
| synthetic, 1600 non-folding muxes | ~0s | ~0s |

`customer_veer_eh2` total synthesis went 329s -> 305s. Output is bit-identical in both cases.

## Test plan

- [x] `tests/opt/opt_mux_odc.ys` passes unchanged (covers the partial-selection guard, which
      is preserved by filtering the fanout on `selected`)
- [x] `qor_tagram_set_hash_mod7` still folds: LoL 30.75, area 162.2, clk 388.3ps — identical
      to before
- [x] Full Preqorsor regression suite

Made with [Cursor](https://cursor.com)