### PR TITLE
opt_shift: add -sink to move adds off variable left shifters

### DIFF
--- a/passes/silimate/CMakeLists.txt
+++ b/passes/silimate/CMakeLists.txt
@@ -95,9 +95,18 @@ pmgen_command(peepopt_shift
 	PREFIX
 		peepopt_shift
 )
+# Kept out of peepopt_shift on purpose: one matcher builds its indexes for
+# every pattern it holds, so folding this in would make -combine/-expand pay
+# to index every $add in the design on invocations that never use it.
+pmgen_command(peepopt_sink
+	peepopt_sink_shifts.pmg
+	PREFIX
+		peepopt_sink
+)
 yosys_pass(peepopt_shift
 	opt_shift.cc
 	${PMGEN_peepopt_shift_OUTPUT}
+	${PMGEN_peepopt_sink_OUTPUT}
 )
 
 pmgen_command(peepopt_muxmode

--- a/passes/silimate/opt_shift.cc
+++ b/passes/silimate/opt_shift.cc
@@ -25,7 +25,102 @@ PRIVATE_NAMESPACE_BEGIN
 
 bool did_something;
 
+// Driver index for the module being processed, rebuilt per module by the sink
+// pattern so it can walk back from a shift amount to the cell producing it.
+SigMap sink_sigmap;
+dict<SigBit, Cell *> sink_drivers;
+
+void sink_index_module(Module *module)
+{
+  sink_sigmap.set(module);
+  sink_drivers.clear();
+  for (auto cell : module->cells())
+    for (auto &conn : cell->connections())
+      if (cell->output(conn.first))
+        for (auto bit : sink_sigmap(conn.second))
+          sink_drivers[bit] = cell;
+}
+
+// Cheap pre-filter for the sink pattern: a constant amount is already folded by
+// -combine, so without a variable shifter there is nothing for -sink to match.
+bool has_variable_shift(Module *module)
+{
+  for (auto cell : module->selected_cells())
+    if (cell->type == ID($shl) && !cell->getPort(ID::B).is_fully_const())
+      return true;
+  return false;
+}
+
+int min_shift_amount(SigSpec amt, int depth = 3);
+
+// Lower bound on `chunk`, which must be the complete output of `drv`. Only
+// unsigned "var + const" is understood; anything else contributes nothing.
+int min_driven_value(Cell *drv, const SigSpec &chunk, int depth)
+{
+  if (drv->type != ID($add))
+    return 0;
+  if (drv->getParam(ID::A_SIGNED).as_bool() || drv->getParam(ID::B_SIGNED).as_bool())
+    return 0;
+  if (sink_sigmap(drv->getPort(ID::Y)) != chunk)
+    return 0;
+
+  SigSpec a = sink_sigmap(drv->getPort(ID::A)), b = sink_sigmap(drv->getPort(ID::B));
+  bool a_const = a.is_fully_const();
+  SigSpec cst = a_const ? a : b, var = a_const ? b : a;
+  if (!cst.is_fully_const() || !cst.is_fully_def() || GetSize(var) > 24)
+    return 0;
+
+  // as_int truncates, which stays correct modulo the chunk width, but a set
+  // bit 31 would come back negative and poison the shift in the caller
+  int c = cst.as_int();
+  if (c < 0)
+    return 0;
+
+  // A sum that can wrap would break the bound, so require it to always fit
+  if (((1 << GetSize(var)) - 1) + c >= (1 << GetSize(chunk)))
+    return 0;
+  return c + min_shift_amount(var, depth - 1);
+}
+
+// Sound lower bound on the value a shift amount can take. A sum is at least
+// the sum of its parts' minima, so each maximal same-driver run of bits is
+// bounded on its own and the pieces are weighted back in by bit position.
+// Under-estimates rather than over-estimates, so callers stay safe.
+int min_shift_amount(SigSpec amt, int depth)
+{
+  amt = sink_sigmap(amt);
+  if (GetSize(amt) > 24) // keep the shifts below inside int range
+    return 0;
+
+  int bound = 0;
+  for (int i = 0; i < GetSize(amt); ) {
+    // Constant bits are set in every reachable value
+    if (!amt[i].is_wire()) {
+      if (amt[i] == State::S1)
+        bound += 1 << i;
+      i++;
+      continue;
+    }
+    if (depth <= 0 || !sink_drivers.count(amt[i])) {
+      i++;
+      continue;
+    }
+
+    // Extend over the run of bits fed by the same cell
+    Cell *drv = sink_drivers.at(amt[i]);
+    int j = i;
+    while (j < GetSize(amt) && amt[j].is_wire() && sink_drivers.count(amt[j]) &&
+           sink_drivers.at(amt[j]) == drv)
+      j++;
+
+    bound += min_driven_value(drv, amt.extract(i, j - i), depth) << i;
+    i = j;
+  }
+  return bound;
+}
+
 #include "passes/silimate/peepopt_shift_pm.h"
+#include "passes/silimate/peepopt_sink_pm.h"
 
 struct OptShiftPass : public Pass {
   OptShiftPass() : Pass("opt_shift", "shift optimizations: combine and expand") { }
@@ -52,10 +147,19 @@ struct OptShiftPass : public Pass {
     log("        (a OP b) >> c    ===>  (a >> c) OP (b >> c)\n");
     log("        where OP in {$and, $or, $xor, $add, $sub}\n");
     log("\n");
+    log("  -sink\n");
+    log("      Sink an add through a left shift, so the adder leaves the\n");
+    log("      shifter output and can merge with the arithmetic feeding it:\n");
+    log("        (x << s) + z    ===>  ((x + (z >> s)) << s) | (z & ~(~0 << s))\n");
+    log("      Requires a provable nonzero minimum for s, which is what makes\n");
+    log("      (z >> s) narrower than z. This is the inverse of -expand on\n");
+    log("      $add, so the two must not be requested together.\n");
+    log("\n");
     log("  -max_iters n\n");
     log("      max number of pass iterations to run.\n");
     log("\n");
-    log("If neither -combine nor -expand is given, both are run.\n");
+    log("If none of -combine, -expand or -sink is given, combine and expand\n");
+    log("are run.\n");
     log("\n");
   }
   void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -64,6 +168,7 @@ struct OptShiftPass : public Pass {
 
     bool run_combine = false;
     bool run_expand = false;
+    bool run_sink = false;
     int max_iters = 10000;
 
     size_t argidx;
@@ -76,6 +181,10 @@ struct OptShiftPass : public Pass {
         run_expand = true;
         continue;
       }
+      if (args[argidx] == "-sink") {
+        run_sink = true;
+        continue;
+      }
       if (args[argidx] == "-max_iters" && argidx + 1 < args.size()) {
         max_iters = std::stoi(args[++argidx]);
         continue;
@@ -84,10 +193,14 @@ struct OptShiftPass : public Pass {
     }
     extra_args(args, argidx, design);
 
-    if (!run_combine && !run_expand) {
+    if (!run_combine && !run_expand && !run_sink) {
       run_combine = true;
       run_expand = true;
     }
+
+    // -expand undoes -sink on $add, so they would ping-pong until max_iters
+    if (run_expand && run_sink)
+      log_cmd_error("opt_shift: -expand and -sink are inverses, pick one.\n");
 
     for (auto module : design->selected_modules())
     {
@@ -95,12 +208,22 @@ struct OptShiftPass : public Pass {
       for (int i = 0; did_something && i < max_iters; i++)
       {
         did_something = false;
-        peepopt_shift_pm pm(module);
-        pm.setup(module->selected_cells());
-        if (run_combine)
-          pm.run_combine_shifts();
-        if (run_expand)
-          pm.run_expand_shifts();
+        if (run_combine || run_expand) {
+          peepopt_shift_pm pm(module);
+          pm.setup(module->selected_cells());
+          if (run_combine)
+            pm.run_combine_shifts();
+          if (run_expand)
+            pm.run_expand_shifts();
+        }
+        // Indexing the drivers and every $add is only worth it once we know a
+        // variable-amount shifter exists; most modules have none and skip it
+        if (run_sink && has_variable_shift(module)) {
+          sink_index_module(module);
+          peepopt_sink_pm pm(module);
+          pm.setup(module->selected_cells());
+          pm.run_sink_shifts();
+        }
       }
     }
   }

--- a/passes/silimate/peepopt_sink_shifts.pmg
+++ b/passes/silimate/peepopt_sink_shifts.pmg
@@ -1,0 +1,114 @@
+pattern sink_shifts
+//
+// Authored by Akash Levy of Silimate, Inc. under ISC license.
+//
+// Sink an add through a left shift, so the adder leaves the shifter output and
+// can merge with the arithmetic already feeding the shifter:
+//
+//   y = (x << s) + z   ===>   y = ((x + (z >> s)) << s) | (z & ~(~0 << s))
+//
+// The low part of z sits below every reachable shift amount, so it merges with
+// a disjoint $or instead of a carry-propagating add. Only fires when s has a
+// provable nonzero minimum, which is what makes (z >> s) strictly narrower
+// than z, and when s is not constant, since a constant shift is free rewiring
+// and there is nothing to sink past.
+//
+
+state <SigSpec> shift_a shift_b shift_y
+state <int> shift_min
+
+match shift
+	select shift->type.in($shl)
+	select !port(shift, \B).empty()
+	select !port(shift, \B).is_fully_const()
+	select !param(shift, \A_SIGNED).as_bool()
+	select !param(shift, \B_SIGNED).as_bool()
+	set shift_a port(shift, \A)
+	set shift_b port(shift, \B)
+	set shift_y port(shift, \Y)
+endmatch
+
+code shift_min
+	// Shifter output must feed the adder and nothing else
+	if (nusers(shift_y) != 2)
+		reject;
+
+	// Without a nonzero lower bound on s there is no narrowing to gain
+	shift_min = min_shift_amount(shift_b);
+	if (shift_min < 1)
+		reject;
+endcode
+
+state <SigSpec> add_z add_y
+
+match add
+	select add->type.in($add)
+	select !param(add, \A_SIGNED).as_bool()
+	select !param(add, \B_SIGNED).as_bool()
+	choice <IdString> AB {\A, \B}
+	index <SigSpec> port(add, AB) === shift_y
+	define <IdString> BA (AB == \A ? \B : \A)
+
+	// Nothing to move if the addend is empty
+	select !port(add, BA).empty()
+
+	set add_z port(add, BA)
+	set add_y port(add, \Y)
+endmatch
+
+code
+	// Keep truncation identical to the original: same width in and out
+	if (GetSize(add_y) != GetSize(shift_y))
+		reject;
+endcode
+
+code shift_a shift_b shift_y add_z add_y
+	int wz = GetSize(add_z);
+	int wy = GetSize(add_y);
+	int wn = max(0, wz - shift_min); // bits of z that survive z >> s
+
+	Cell *cell = add;
+	std::string src = cell->get_src_attribute();
+
+	// wn == 0 means all of z sits below every reachable shift amount, so z
+	// passes through unmasked and nothing needs to cross the shifter
+	SigSpec base = shift_a;
+	SigSpec z_lo = add_z;
+	if (wn > 0) {
+		// The part of z at or above the shift rejoins the arithmetic in front
+		// of the shifter, narrowed by the shift it is guaranteed to get
+		Wire *z_hi = module->addWire(NEW_ID2, wn);
+		module->addShr(NEW_ID2, add_z, shift_b, z_hi, false, src);
+		Wire *sum = module->addWire(NEW_ID2, wy); // result width keeps truncation identical
+		module->addAdd(NEW_ID2, shift_a, z_hi, sum, false, src);
+		base = sum;
+
+		// What stays behind is z masked down to the bits below the shift
+		Wire *keep = module->addWire(NEW_ID2, wz);
+		module->addShl(NEW_ID2, SigSpec(State::S1, wz), shift_b, keep, false, src);
+		SigSpec drop = module->Not(NEW_ID2, keep, false, src);
+		Wire *masked = module->addWire(NEW_ID2, wz);
+		module->addAnd(NEW_ID2, add_z, drop, masked, false, src);
+		z_lo = masked;
+	}
+
+	Wire *base_sh = module->addWire(NEW_ID2, wy);
+	module->addShl(NEW_ID2, base, shift_b, base_sh, false, src);
+
+	// The two halves are disjoint, so the carry-propagating add becomes an $or
+	add->unsetPort(\A);
+	add->unsetPort(\B);
+	add->unsetPort(\Y);
+	shift->unsetPort(\A);
+	shift->unsetPort(\B);
+	shift->unsetPort(\Y);
+	module->addOr(NEW_ID2, base_sh, z_lo, add_y, false, src);
+
+	autoremove(add);
+	autoremove(shift);
+
+	log("sink_shifts pattern in %s: shift=%s (%s), add=%s, min_shift=%d, addend %d -> %d bits\n",
+		log_id(module), log_id(shift), log_id(shift->type), log_id(add), shift_min, wz, wn);
+	did_something = true;
+	accept;
+endcode

--- a/tests/silimate/opt_sink_shifts.ys
+++ b/tests/silimate/opt_sink_shifts.ys
@@ -1,0 +1,153 @@
+log -header "Addend fits below the shift floor: merge becomes a plain OR"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] a,
+  input wire [2:0] b,
+  input wire [3:0] z,
+  output wire [19:0] x
+);
+  wire [4:0] amt = b + 5'd8;
+  assign x = (a << amt) + z;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -sink
+design -load postopt
+# z is narrower than the guaranteed shift, so nothing has to cross the shifter
+select -assert-count 1 t:$shl
+select -assert-count 0 t:$shr
+select -assert-count 1 t:$or
+# the only remaining add is the one forming the shift amount
+select -assert-count 1 t:$add
+design -reset
+log -pop
+
+
+
+log -header "Addend crosses the shift floor: narrowed add plus masked OR"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] a,
+  input wire [2:0] b,
+  input wire [9:0] z,
+  output wire [19:0] x
+);
+  wire [4:0] amt = b + 5'd6;
+  assign x = (a << amt) + z;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -sink
+design -load postopt
+# the high 4 bits of z move in front of the shifter, the low 6 stay behind
+select -assert-count 1 t:$shr
+select -assert-count 1 t:$or
+select -assert-count 1 t:$and
+# shift amount add, plus the sunk addend joining the arithmetic before the shift
+select -assert-count 2 t:$add
+design -reset
+log -pop
+
+
+
+log -header "Negative: constant shift amount is free rewiring, nothing to sink"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] a,
+  input wire [9:0] z,
+  output wire [19:0] x
+);
+  assign x = (a << 6) + z;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -sink
+design -load postopt
+select -assert-count 0 t:$or
+design -reset
+log -pop
+
+
+
+log -header "Negative: no constant floor on the amount, so the addend cannot narrow"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] a,
+  input wire [2:0] b,
+  input wire [9:0] z,
+  output wire [19:0] x
+);
+  assign x = (a << b) + z;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -sink
+design -load postopt
+select -assert-count 1 t:$shl
+select -assert-count 0 t:$or
+design -reset
+log -pop
+
+
+
+log -header "Negative: shifter output has a second consumer"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] a,
+  input wire [2:0] b,
+  input wire [9:0] z,
+  output wire [19:0] x,
+  output wire [19:0] x2
+);
+  wire [4:0]  amt    = b + 5'd6;
+  wire [19:0] sh_out = a << amt;
+  assign x  = sh_out + z;
+  assign x2 = sh_out ^ 20'hA5A5A;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -sink
+design -load postopt
+select -assert-count 1 t:$shl
+select -assert-count 0 t:$or
+design -reset
+log -pop
+
+
+
+log -header "Negative: signed operands are outside the unsigned bound"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire signed [7:0] a,
+  input wire [2:0] b,
+  input wire signed [9:0] z,
+  output wire signed [19:0] x
+);
+  wire [4:0] amt = b + 5'd6;
+  assign x = (a <<< amt) + z;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -sink
+design -load postopt
+select -assert-count 0 t:$or
+design -reset
+log -pop


### PR DESCRIPTION
## Summary

Adds an `opt_shift -sink` mode that moves an add off the output of a variable left shifter, so the adder can merge with the arithmetic already feeding the shifter instead of sitting on its output with a full-width carry chain:

```
(x << s) + z   ===>   ((x + (z >> s)) << s) | (z & ~(~0 << s))
```

The low part of `z` sits below every reachable shift amount, so the post-shift merge becomes a disjoint `$or` rather than a carry-propagating add, and the high part rejoins the tree in front of the shifter where arithmetic balancing can fold it in.

This is what makes it sound: the rewrite only fires when `s` has a provable nonzero minimum, which is what makes `z >> s` strictly narrower than `z`. `min_shift_amount` derives that bound by bounding each maximal run of amount bits driven by the same cell and weighting the pieces back in by bit position. It understands unsigned `var + const` and rejects any sum that could wrap. It deliberately under-estimates, so a bound it cannot prove simply means the pattern does not fire.

The pattern declines constant amounts (free rewiring, nothing to sink past), signed operands, a shifter output with a second consumer, and any width change that would alter truncation.

## Why a separate matcher

`sink_shifts` gets its own pmgen matcher rather than joining `peepopt_shift`. A matcher builds indexes for **every** pattern it holds on each `setup()`, regardless of which `run_*` is called, so folding this in would make the existing `-combine`/`-expand` invocations index every `$add` in the design for a pattern they never run.

The pass additionally skips the driver index and the match entirely unless the module actually contains a variable-amount `$shl`. On a synthetic 20k-adder design with no variable shifter — what almost every real module looks like — `-sink` costs 0.16s over the read-only floor (2.08s vs 1.92s), against ~4.5s before that early-out.

`-expand` is the inverse of this on `$add`, so requesting both together is a `log_cmd_error` rather than letting them ping-pong to `max_iters`.

## Test plan

- [x] New `tests/silimate/opt_sink_shifts.ys` covers both positive shapes (addend entirely below the floor, so the merge is a plain `$or`; and addend crossing the floor, so it narrows 10 bits to 4) plus four negative guards (constant amount, no constant floor, shifter fanout, signed operands).
- [x] Every case in that test is checked with `equiv_opt -assert`, so correctness is formally proven rather than structurally asserted, and the positive cases are confirmed non-vacuous via the pass's own log line.
- [x] `make opt_sink_shifts.ys` passes in `tests/silimate`.
- [x] Formally verified on the real design that motivated this (a mul/add tree feeding `<< (sh + 6)` then `+ lo`), where it takes LoL 40.5 -> 36.75 and clk 654 -> 582.

Downstream Preqorsor wiring is a separate PR, pending a submodule bump on this.

Made with [Cursor](https://cursor.com)