### PR TITLE
arith_tree: readable compressor names, and word-level $fa lowering

### DIFF
--- a/kernel/compressor_tree.cc
+++ b/kernel/compressor_tree.cc
@@ -5,11 +5,11 @@ YOSYS_NAMESPACE_BEGIN
 namespace CompressorTree
 {
 
-std::pair<SigSpec, SigSpec> emit_compressor_32(Module *module, SigSpec a, SigSpec b, SigSpec c, int width)
+std::pair<SigSpec, SigSpec> emit_compressor_32(Module *module, SigSpec a, SigSpec b, SigSpec c, int width, IdString cell_name)
 {
-	SigSpec sum = module->addWire(NEW_ID, width);
-	SigSpec cout = module->addWire(NEW_ID, width);
-	module->addFa(NEW_ID, a, b, c, cout, sum);
+	SigSpec sum = module->addWire(NEW_ID3_SUFFIX("fa_sum"), width); // SILIMATE: Improve the naming
+	SigSpec cout = module->addWire(NEW_ID3_SUFFIX("fa_cout"), width); // SILIMATE: Improve the naming
+	module->addFa(NEW_ID3_SUFFIX("fa"), a, b, c, cout, sum); // SILIMATE: Improve the naming
 
 	SigSpec carry;
 	carry.append(State::S0);
@@ -17,12 +17,12 @@ std::pair<SigSpec, SigSpec> emit_compressor_32(Module *module, SigSpec a, SigSpe
 	return {sum, carry};
 }
 
-std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpec b, SigSpec c, SigSpec d, int width)
+std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpec b, SigSpec c, SigSpec d, int width, IdString cell_name)
 {
 	// First FA: a + b + c -> s0
-	SigSpec s0 = module->addWire(NEW_ID, width);
-	SigSpec cout_h_full = module->addWire(NEW_ID, width);
-	module->addFa(NEW_ID, a, b, c, cout_h_full, s0);
+	SigSpec s0 = module->addWire(NEW_ID3_SUFFIX("c42_sum"), width); // SILIMATE: Improve the naming
+	SigSpec cout_h_full = module->addWire(NEW_ID3_SUFFIX("c42_cout"), width); // SILIMATE: Improve the naming
+	module->addFa(NEW_ID3_SUFFIX("c42_lo"), a, b, c, cout_h_full, s0); // SILIMATE: Improve the naming
 
 	// cin[0] = 0, cin[i] = cout_h_full[i-1]
 	SigSpec cin;
@@ -31,9 +31,9 @@ std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpe
 		cin.append(cout_h_full.extract(0, width - 1));
 
 	// Second FA: s0 + d + cin -> sum
-	SigSpec sum = module->addWire(NEW_ID, width);
-	SigSpec carry_full = module->addWire(NEW_ID, width);
-	module->addFa(NEW_ID, s0, d, cin, carry_full, sum);
+	SigSpec sum = module->addWire(NEW_ID3_SUFFIX("c42_out"), width); // SILIMATE: Improve the naming
+	SigSpec carry_full = module->addWire(NEW_ID3_SUFFIX("c42_carry"), width); // SILIMATE: Improve the naming
+	module->addFa(NEW_ID3_SUFFIX("c42_hi"), s0, d, cin, carry_full, sum); // SILIMATE: Improve the naming
 
 	SigSpec carry;
 	carry.append(State::S0);
@@ -43,7 +43,7 @@ std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpe
 	return {sum, carry};
 }
 
-std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSpec b, bool a_signed, bool b_signed, int width) {
+std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSpec b, bool a_signed, bool b_signed, int width, IdString cell_name) {
 	int width_a = GetSize(a);
 	int width_b = GetSize(b);
 	std::vector<DepthSig> products;
@@ -59,8 +59,8 @@ std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSp
 
 		// row = b_shifted & replicate(a[i], width)
 		SigSpec ai_rep = SigSpec(ai, width);
-		SigSpec row = module->addWire(NEW_ID, width);
-		module->addAnd(NEW_ID, b_shifted, ai_rep, row);
+		SigSpec row = module->addWire(NEW_ID3_SUFFIX("pp"), width); // SILIMATE: Improve the naming
+		module->addAnd(NEW_ID3_SUFFIX("pp_and"), b_shifted, ai_rep, row); // SILIMATE: Improve the naming
 
 		// Apply Modified Baugh-Wooley inversions for this row
 		bool row_is_bottom = (i == width_a - 1);
@@ -88,8 +88,8 @@ std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSp
 					break;
 				}
 			if (nonzero) {
-				SigSpec inverted = module->addWire(NEW_ID, width);
-				module->addXor(NEW_ID, row, SigSpec(RTLIL::Const(mask)), inverted);
+				SigSpec inverted = module->addWire(NEW_ID3_SUFFIX("pp_inv"), width); // SILIMATE: Improve the naming
+				module->addXor(NEW_ID3_SUFFIX("pp_xor"), row, SigSpec(RTLIL::Const(mask)), inverted); // SILIMATE: Improve the naming
 				row = inverted;
 			}
 		}
@@ -116,7 +116,7 @@ std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSp
 	return products;
 }
 
-std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSig> operands, int width, Strategy strategy, int *out_compressor_count, int *out_final_depth) {
+std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSig> operands, int width, Strategy strategy, IdString cell_name, int *out_compressor_count, int *out_final_depth) {
 	int levels = 0;
 	int fa_count = 0;
 	int c42_count = 0;
@@ -162,7 +162,7 @@ std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSi
 				DepthSig c = ready[i + 2];
 				DepthSig d = ready[i + 3];
 
-				auto [sum, carry] = emit_compressor_42(module, a.sig, b.sig, c.sig, d.sig, width);
+				auto [sum, carry] = emit_compressor_42(module, a.sig, b.sig, c.sig, d.sig, width, cell_name);
 				int dmax = std::max({a.depth, b.depth, c.depth, d.depth});
 
 				compressed.push_back({sum, dmax + 2});
@@ -176,7 +176,7 @@ std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSi
 				DepthSig b = ready[i + 1];
 				DepthSig c = ready[i + 2];
 
-				auto [sum, carry] = emit_compressor_32(module, a.sig, b.sig, c.sig, width);
+				auto [sum, carry] = emit_compressor_32(module, a.sig, b.sig, c.sig, width, cell_name);
 				int dmax = std::max({a.depth, b.depth, c.depth});
 
 				compressed.push_back({sum, dmax + 1});
@@ -221,7 +221,7 @@ std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSi
 	return {operands[0].sig, operands[1].sig};
 }
 
-void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y)
+void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y, IdString cell_name)
 {
 	int width = GetSize(y);
 	log_assert(GetSize(a) == width);
@@ -231,17 +231,17 @@ void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y)
 		return;
 
 	if (width == 1) {
-		module->addXorGate(NEW_ID, a[0], b[0], y[0]);
+		module->addXorGate(NEW_ID3_SUFFIX("ks_sum"), a[0], b[0], y[0]); // SILIMATE: Improve the naming
 		return;
 	}
 
 	// Bit level gen and prop
 	std::vector<SigBit> g_pre(width), p_pre(width);
 	for (int i = 0; i < width; i++) {
-		SigBit gi = module->addWire(NEW_ID);
-		SigBit pi = module->addWire(NEW_ID);
-		module->addAndGate(NEW_ID, a[i], b[i], gi);
-		module->addXorGate(NEW_ID, a[i], b[i], pi);
+		SigBit gi = module->addWire(NEW_ID3_SUFFIX("ks_g")); // SILIMATE: Improve the naming
+		SigBit pi = module->addWire(NEW_ID3_SUFFIX("ks_p")); // SILIMATE: Improve the naming
+		module->addAndGate(NEW_ID3_SUFFIX("ks_g_and"), a[i], b[i], gi); // SILIMATE: Improve the naming
+		module->addXorGate(NEW_ID3_SUFFIX("ks_p_xor"), a[i], b[i], pi); // SILIMATE: Improve the naming
 		g_pre[i] = gi;
 		p_pre[i] = pi;
 	}
@@ -264,16 +264,16 @@ void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y)
 				p_next[i] = p[i];
 			} else {
 				// g_i^k = g_i | (p_i & g_(i-s))
-				SigBit and_pg = module->addWire(NEW_ID);
-				module->addAndGate(NEW_ID, p[i], g[i - s], and_pg);
-				SigBit gnew = module->addWire(NEW_ID);
-				module->addOrGate(NEW_ID, g[i], and_pg, gnew);
+				SigBit and_pg = module->addWire(NEW_ID3_SUFFIX("ks_pg")); // SILIMATE: Improve the naming
+				module->addAndGate(NEW_ID3_SUFFIX("ks_pg_and"), p[i], g[i - s], and_pg); // SILIMATE: Improve the naming
+				SigBit gnew = module->addWire(NEW_ID3_SUFFIX("ks_gnext")); // SILIMATE: Improve the naming
+				module->addOrGate(NEW_ID3_SUFFIX("ks_g_or"), g[i], and_pg, gnew); // SILIMATE: Improve the naming
 				g_next[i] = gnew;
 
 				// p_i^k = p_i & p_(i-s)
 				if (k < num_levels) {
-					SigBit pnew = module->addWire(NEW_ID);
-					module->addAndGate(NEW_ID, p[i], p[i - s], pnew);
+					SigBit pnew = module->addWire(NEW_ID3_SUFFIX("ks_pnext")); // SILIMATE: Improve the naming
+					module->addAndGate(NEW_ID3_SUFFIX("ks_p_and"), p[i], p[i - s], pnew); // SILIMATE: Improve the naming
 					p_next[i] = pnew;
 				} else {
 					// Skip last level
@@ -292,17 +292,17 @@ void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y)
 	//   sum[i] = p_pre[i] ^ g[i-1] ...
 	module->connect(y[0], p_pre[0]);
 	for (int i = 1; i < width; i++)
-		module->addXorGate(NEW_ID, p_pre[i], g[i - 1], y[i]);
+		module->addXorGate(NEW_ID3_SUFFIX("ks_sum"), p_pre[i], g[i - 1], y[i]); // SILIMATE: Improve the naming
 }
 
-Cell *emit_final_adder(Module *module, SigSpec a, SigSpec b, SigSpec y, FinalAdder choice) {
+Cell *emit_final_adder(Module *module, SigSpec a, SigSpec b, SigSpec y, FinalAdder choice, IdString cell_name) {
 	switch (choice) {
 		case FinalAdder::DEFAULT:
 		case FinalAdder::RIPPLE: {
-			return module->addAdd(NEW_ID, a, b, y, false);
+			return module->addAdd(NEW_ID3_SUFFIX("cpa"), a, b, y, false); // SILIMATE: Improve the naming
 		}
 		case FinalAdder::PARALLEL_PREFIX: {
-			emit_kogge_stone(module, a, b, y);
+			emit_kogge_stone(module, a, b, y, cell_name);
 			return nullptr;
 		}
 	}

--- a/kernel/compressor_tree.h
+++ b/kernel/compressor_tree.h
@@ -57,8 +57,10 @@ enum class FinalMode {
 	PREFIX,
 };
 
-std::pair<SigSpec, SigSpec> emit_compressor_32(Module *module, SigSpec a, SigSpec b, SigSpec c, int width);
-std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpec b, SigSpec c, SigSpec d, int width);
+// SILIMATE: every emitter takes cell_name, the originating cell, so the emitted
+// logic inherits a readable name instead of an $auto$file.cc:line$id one
+std::pair<SigSpec, SigSpec> emit_compressor_32(Module *module, SigSpec a, SigSpec b, SigSpec c, int width, IdString cell_name);
+std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpec b, SigSpec c, SigSpec d, int width, IdString cell_name);
 
 /**
  * generate_partial_products() - Generate partial products for FMA concat
@@ -68,10 +70,11 @@ std::pair<SigSpec, SigSpec> emit_compressor_42(Module *module, SigSpec a, SigSpe
  * @a_signed: Whether signal A is signed
  * @b_signed: Whether signal B is signed
  * @width: Target width
+ * @cell_name: Originating cell, used to name the emitted logic
  *
  * Return: Partial-product matrix as a set of depth-0 vectors
  */
-std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSpec b, bool a_signed, bool b_signed, int width);
+std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSpec b, bool a_signed, bool b_signed, int width, IdString cell_name);
 
 /**
  * reduce_scheduled() - Reduce multiple operands to two using a compressor tree
@@ -80,12 +83,13 @@ std::vector<DepthSig> generate_partial_products(Module *module, SigSpec a, SigSp
  * @sigs: Vector of input signals (operands) to be reduced
  * @width: Target bit-width to which all operands will be zero-extended
  * @strategy: Compression strategy to use
+ * @cell_name: Originating cell, used to name the emitted logic
  * @out_compressor_count: Optional pointer to return the number of $fa cells emitted
  * @out_final_depth: Optional pointer to return the final depth of the scheduled tree
  *
  * Return: The final two reduced operands, that are to be fed into an adder
  */
-std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSig> operands, int width, Strategy strategy, int *out_compressor_count = nullptr, int *out_final_depth = nullptr);
+std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSig> operands, int width, Strategy strategy, IdString cell_name, int *out_compressor_count = nullptr, int *out_final_depth = nullptr);
 
 /**
  * emit_kogge_stone() - Emit a Kogge-Stone parallel-prefix adder
@@ -93,8 +97,9 @@ std::pair<SigSpec, SigSpec> reduce_scheduled(Module *module, std::vector<DepthSi
  * @a: Signal A
  * @b: Signal B
  * @y: Signal Y = (A + B) mod 2^W
+ * @cell_name: Originating cell, used to name the emitted logic
  */
-void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y);
+void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y, IdString cell_name);
 
 /**
  * emit_final_adder() - Emit the final carry-propagate addition between the two reduced vectors
@@ -103,10 +108,11 @@ void emit_kogge_stone(Module *module, SigSpec a, SigSpec b, SigSpec y);
  * @b: Signal B
  * @y: Signal Y
  * @choice: Adder type to instantiate
+ * @cell_name: Originating cell, used to name the emitted logic
  *
  * Return: Cell* of the emitted instance
  */
-Cell *emit_final_adder(Module *module, SigSpec a, SigSpec b, SigSpec y, FinalAdder choice);
+Cell *emit_final_adder(Module *module, SigSpec a, SigSpec b, SigSpec y, FinalAdder choice, IdString cell_name);
 
 FinalAdder pick_final_adder(int width, int final_depth, FinalMode mode);
 

--- a/passes/techmap/arith_tree.cc
+++ b/passes/techmap/arith_tree.cc
@@ -310,7 +310,7 @@ struct ArithTreeWorker {
 				pool.push_back({op.sig, 0});
 			} else {
 				// Multiplicative operand
-				auto pps = CompressorTree::generate_partial_products(module, op.sig, op.factor_b, op.is_signed, op.factor_b_signed, width);
+				auto pps = CompressorTree::generate_partial_products(module, op.sig, op.factor_b, op.is_signed, op.factor_b_signed, width, cell->name); // SILIMATE: Improve the naming
 
 				if (!op.negate) {
 					for (auto &pp : pps)
@@ -318,7 +318,7 @@ struct ArithTreeWorker {
 					continue;
 				}
 
-				auto [pa, pb] = CompressorTree::reduce_scheduled(module, pps, width, opt.strategy);
+				auto [pa, pb] = CompressorTree::reduce_scheduled(module, pps, width, opt.strategy, cell->name); // SILIMATE: Improve the naming
 				SigSpec p = module->addWire(NEW_ID2_SUFFIX("prod"), width); // SILIMATE: Improve the naming
 				module->addAdd(NEW_ID2_SUFFIX("add"), pa, pb, p, false); // SILIMATE: Improve the naming
 				SigSpec np = module->addWire(NEW_ID2_SUFFIX("nprod"), width); // SILIMATE: Improve the naming
@@ -339,9 +339,9 @@ struct ArithTreeWorker {
 		int width = GetSize(result_y);
 		auto pool = build_operand_pool(cell, operands, width, neg_compensation);
 		int final_depth = 0;
-		auto [a, b] = CompressorTree::reduce_scheduled(module, std::move(pool), width, opt.strategy, nullptr, &final_depth);
+		auto [a, b] = CompressorTree::reduce_scheduled(module, std::move(pool), width, opt.strategy, cell->name, nullptr, &final_depth); // SILIMATE: Improve the naming
 		auto final_choice = CompressorTree::pick_final_adder(width, final_depth, opt.final_mode);
-		CompressorTree::emit_final_adder(module, a, b, result_y, final_choice);
+		CompressorTree::emit_final_adder(module, a, b, result_y, final_choice, cell->name); // SILIMATE: Improve the naming
 	}
 
 	void process_chains()

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -393,7 +393,7 @@ struct BoothPassWorker {
 		operands.reserve(aligned_pp.size());
 		for (auto &s : aligned_pp)
 			operands.push_back({s, 0});
-		auto [wtree_a, wtree_b] = CompressorTree::reduce_scheduled(module, std::move(operands), z_sz, CompressorTree::Strategy::FA_ONLY);
+		auto [wtree_a, wtree_b] = CompressorTree::reduce_scheduled(module, std::move(operands), z_sz, CompressorTree::Strategy::FA_ONLY, cell->name); // SILIMATE: Improve the naming
 
 		// Debug code: Dump out the csa trees
 		// DumpCSATrees(debug_csa_trees);

--- a/passes/tests/test_kogge_stone.cc
+++ b/passes/tests/test_kogge_stone.cc
@@ -94,7 +94,7 @@ struct TestKoggeStonePass : public Pass {
 		build_lcu_adder(gold, gold->wire(ID(a)), gold->wire(ID(b)), gold->wire(ID(y)));
 
 		Module *gate = make_module(design, gate_name, width);
-		CompressorTree::emit_kogge_stone(gate, gate->wire(ID(a)), gate->wire(ID(b)), gate->wire(ID(y)));
+		CompressorTree::emit_kogge_stone(gate, gate->wire(ID(a)), gate->wire(ID(b)), gate->wire(ID(y)), ID(ks));
 	}
 } TestKoggeStonePass;
 

--- a/techlibs/common/CMakeLists.txt
+++ b/techlibs/common/CMakeLists.txt
@@ -42,6 +42,7 @@ yosys_pass(synth
 		abc9_unmap.v
 		cmp2lcu.v
 		cmp2softlogic.v
+		fa_wordlevel.v
 
 		choices/kogge-stone.v
 		choices/han-carlson.v

--- a/techlibs/common/fa_wordlevel.v
+++ b/techlibs/common/fa_wordlevel.v
@@ -1,0 +1,20 @@
+// Lower $fa to word-level $xor/$and/$or instead of gates.
+//
+// Consumers that model word-level operators (rather than mapped gates) need the
+// carry-save compressors emitted by arith_tree to stay at operator granularity,
+// so a full adder becomes wide bitwise ops rather than a bit-blasted cloud.
+
+(* techmap_celltype = "$fa" *)
+module _fa_wordlevel_ (A, B, C, X, Y);
+
+parameter WIDTH = 1;
+
+input [WIDTH-1:0] A, B, C;
+output [WIDTH-1:0] X, Y;
+
+wire [WIDTH-1:0] t1 = A ^ B;
+
+assign Y = t1 ^ C;  // sum
+assign X = (A & B) | (C & t1);  // carry-out (majority)
+
+endmodule

--- a/tests/arith_tree/arith_tree_42.ys
+++ b/tests/arith_tree/arith_tree_42.ys
@@ -1,3 +1,5 @@
+# Compressors are named after the cell they came from, so the 3:2 and 4:2 paths
+# are told apart by their _fa / _c42_ suffixes rather than by the emitter name.
 read_verilog <<EOT
 module four_op_42(
 	input [3:0] a, b, c, d,
@@ -12,8 +14,8 @@ equiv_opt -assert arith_tree -strategy 42
 design -load postopt
 select -assert-count 2 t:$fa
 select -assert-count 1 t:$add
-select -assert-count 2 t:$fa c:*emit_compressor_42* %i
-select -assert-count 0 t:$fa c:*emit_compressor_32* %i
+select -assert-count 2 t:$fa c:*_c42_* %i
+select -assert-count 0 t:$fa c:*_fa* %i
 design -reset
 
 read_verilog <<EOT
@@ -30,8 +32,8 @@ equiv_opt -assert arith_tree -strategy fa
 design -load postopt
 select -assert-count 2 t:$fa
 select -assert-count 1 t:$add
-select -assert-count 0 t:$fa c:*emit_compressor_42* %i
-select -assert-count 2 t:$fa c:*emit_compressor_32* %i
+select -assert-count 0 t:$fa c:*_c42_* %i
+select -assert-count 2 t:$fa c:*_fa* %i
 design -reset
 
 read_verilog <<EOT
@@ -48,7 +50,7 @@ equiv_opt -assert arith_tree -strategy 42
 design -load postopt
 select -assert-count 6 t:$fa
 select -assert-count 1 t:$add
-select -assert-min 1 t:$fa c:*emit_compressor_42* %i
+select -assert-min 1 t:$fa c:*_c42_* %i
 design -reset
 
 read_verilog <<EOT
@@ -67,7 +69,7 @@ equiv_opt -assert arith_tree -strategy 42
 design -load postopt
 select -assert-count 14 t:$fa
 select -assert-count 1 t:$add
-select -assert-min 1 t:$fa c:*emit_compressor_42* %i
+select -assert-min 1 t:$fa c:*_c42_* %i
 design -reset
 
 read_verilog <<EOT
@@ -84,7 +86,7 @@ equiv_opt -assert arith_tree -strategy 42
 design -load postopt
 select -assert-count 3 t:$fa
 select -assert-count 1 t:$add
-select -assert-min 1 t:$fa c:*emit_compressor_42* %i
+select -assert-min 1 t:$fa c:*_c42_* %i
 design -reset
 
 read_verilog <<EOT
@@ -101,7 +103,7 @@ equiv_opt -assert arith_tree -strategy 42
 design -load postopt
 select -assert-count 4 t:$fa
 select -assert-count 1 t:$add
-select -assert-min 1 t:$fa c:*emit_compressor_42* %i
+select -assert-min 1 t:$fa c:*_c42_* %i
 design -reset
 
 read_verilog <<EOT
@@ -118,5 +120,5 @@ equiv_opt -assert arith_tree -strategy 42
 design -load postopt
 select -assert-count 5 t:$fa
 select -assert-count 1 t:$add
-select -assert-min 1 t:$fa c:*emit_compressor_42* %i
+select -assert-min 1 t:$fa c:*_c42_* %i
 design -reset


### PR DESCRIPTION
Two independent changes that together let `arith_tree`'s carry-save output be consumed by a word-level modeling flow. Split into one commit each.

## 1. `compressor_tree`: name emitted logic after the originating cell

`kernel/compressor_tree.cc` never went through the naming cleanup that `arith_tree` and `booth` already had, so every `$fa`, wire and gate came from a raw `NEW_ID`. Carry-save logic landed in netlists with no link back to the RTL it came from:

| Before | After |
|---|---|
| `$auto$compressor_tree.cc:302:emit_final_adder$12` | `$add$dut.v:10$2_cpa` |
| `$auto$compressor_tree.cc:12:emit_compressor_32$8` | `$add$dut.v:10$2_fa` |
| `$auto$compressor_tree.cc:12:emit_compressor_32$11` | `$add$dut.v:10$2_fa_1` |

These are free functions taking `Module *`, so there is no `cell` in scope for `NEW_ID2`. They now take the originating `cell_name` and use `NEW_ID3_SUFFIX`, which produces the same style of name. Callers pass `cell->name` (`arith_tree`, `booth`) or a literal (`test_kogge_stone`).

Note this is observable behaviour for anything selecting on cell names: `arith_tree_42` distinguished the 3:2 and 4:2 paths via `c:*emit_compressor_42*`, and now selects on the `_fa` / `_c42_` suffixes.

## 2. `techlibs/common`: add `fa_wordlevel.v`

`techmap.v` lowers `$fa` to gates. That is the wrong granularity for consumers that model word-level operators — the compressors `arith_tree` emits get bit-blasted into a gate cloud. This lowers `$fa` to wide `$xor`/`$and`/`$or` instead, so with `-final ripple` the whole carry-save tree stays at operator granularity and the final adder stays a word-level `$add`.

Added to `DATA_FILES` so a clean build installs it as `+/fa_wordlevel.v`.

## Test plan

- [x] `tests/arith_tree` 13/13 pass, including `kogge_stone_equiv` and `arith_tree_42`
- [x] `equiv_opt -assert booth` on a signed 8x8 multiply still proves, with `$fa` cells present
- [x] `arith_tree -strategy fa -final ripple` then `techmap -map +/fa_wordlevel.v t:$fa` proven equivalent to `a - b + c` and `a + b + c + d` by SAT miter ("no model found: SUCCESS!")
- [x] Result after lowering is `$add`/`$and`/`$not`/`$or`/`$xor` only, with zero `$fa` and zero gate primitives
