### PR TITLE
Enrich silimate pass help() with durable algorithm notes

### DIFF
--- a/passes/silimate/annotate_cell_fanout.cc
+++ b/passes/silimate/annotate_cell_fanout.cc
@@ -644,10 +644,16 @@ struct AnnotateCellFanout : public ScriptPass {
 	void script() override {}
 	void help() override
 	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
 		log("    annotate_cell_fanout [options] [selection]\n");
 		log("\n");
-		log("This pass annotates cell fanout and optionally inserts balanced buffer trees to limit fanout.\n");
+		log("Annotate each cell's fanout. With -limit, insert a recursive balanced buffer\n");
+		log("tree on outputs (and optionally inputs/clocks/resets) that exceed the limit:\n");
+		log("per output chunk, create buffers, reconnect loads round-robin until every\n");
+		log("buffer is at or under the limit, then collapse buffers with fanout 1 to wires.\n");
+		log("Improves area/timing predictions on high-fanout designs. Synthesis typically\n");
+		log("runs fanoutbuf first, then this pass to annotate.\n");
 		log("\n");
 		log("    -limit <limit>\n");
 		log("        Limits the fanout by inserting balanced buffer trees.\n");

--- a/passes/silimate/carvenetlist.cc
+++ b/passes/silimate/carvenetlist.cc
@@ -134,6 +134,19 @@ struct CarveNetlistPass : public Pass {
 		log("a hard boundary: cones never expand through it, so a carve can't leak across the\n");
 		log("clock into another cell's surrounding flops.\n");
 		log("\n");
+		log("Output boundary is reconstructed at capture flops (__pqcarve.<base>_<pin> buses\n");
+		log("driven by per-bit buffers) so feed-through/tie outputs still get clean ports.\n");
+		log("After submod, train. prefixes and __pqi/__pqo suffixes are stripped; only the\n");
+		log("load cell-pin is recorded (no capacitance values).\n");
+		log("\n");
+		log("DESIGN cells (slow_design_<enc>/fast_design_<enc>) get extra repairs: clean\n");
+		log("input ports at the launch boundary, clone/tie undriven constant sources for\n");
+		log("self-containment, retie clocks to shared slow_clk/fast_clk, and skip the final\n");
+		log("1-in/1-out passthrough-to-wire cleanup so real inversions stay equivalent to RTL.\n");
+		log("\n");
+		log("Known issue: fast aes/aes_inv key carves can leave dangling n_<num> inputs when\n");
+		log("the launch flop is QN-output (DFFHQNx1); slow Q-output clones carve cleanly.\n");
+		log("\n");
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override

--- a/passes/silimate/carvenetlist.cc
+++ b/passes/silimate/carvenetlist.cc
@@ -144,8 +144,9 @@ struct CarveNetlistPass : public Pass {
 		log("self-containment, retie clocks to shared slow_clk/fast_clk, and skip the final\n");
 		log("1-in/1-out passthrough-to-wire cleanup so real inversions stay equivalent to RTL.\n");
 		log("\n");
-		log("Known issue: fast aes/aes_inv key carves can leave dangling n_<num> inputs when\n");
-		log("the launch flop is QN-output (DFFHQNx1); slow Q-output clones carve cleanly.\n");
+		log("Known issue: fast QN-output (DFFHQNx1) carves can leave dangling n_<num> inputs,\n");
+		log("including AES keys and some wide arithmetic, shift, memory, division, and modulo\n");
+		log("cells; slow Q-output clones carve cleanly.\n");
 		log("\n");
 	}
 

--- a/passes/silimate/obs_clean.cc
+++ b/passes/silimate/obs_clean.cc
@@ -252,15 +252,21 @@ struct ObsClean : public ScriptPass {
 	void script() override {}
 	void help() override
 	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
 		log("    obs_clean [options] [selection]\n");
 		log("\n");
-		log("This pass performs an obversability-based logic removal. It removes cells by default.\n");
+		log("Remove cells (and optionally assigns) with no structural path to a module output.\n");
+		log("Walks transitive fanin from every output, marks reachable cells/assigns, then\n");
+		log("deletes unmarked ones. Objects with a keep attribute are preserved.\n");
+		log("\n");
+		log("Modules with processes or memories are skipped (connectivity is not modeled).\n");
 		log("\n");
 		log("    -wires\n");
-		log("        Also removes dangling wires. This option prevents formal verifciation at this time.\n");
+		log("        Also remove dangling wires. Off by default: wire removal renames signals\n");
+		log("        and breaks Yosys equiv_opt formal checking.\n");
 		log("    -assigns\n");
-		log("        Also removes dangling assigns.\n");
+		log("        Also remove dangling assigns.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override

--- a/passes/silimate/splitnetlist.cc
+++ b/passes/silimate/splitnetlist.cc
@@ -143,11 +143,24 @@ std::string_view rtrim_until(std::string_view str, char c)
 
 struct SplitNetlist : public ScriptPass {
 	SplitNetlist()
-	    : ScriptPass("splitnetlist", "Splits a netlist into multiple modules using transitive fanin grouping. \
-	       The output names that belong in the same logical cluster have to have the same prefix: <prefix>_<name>")
+	    : ScriptPass("splitnetlist", "split a flat netlist into modules by output-port prefix via transitive fanin")
 	{
 	}
 	void script() override {}
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    splitnetlist\n");
+		log("\n");
+		log("Split a flat top module into multiple modules by clustering transitive fanin of\n");
+		log("output ports that share a name prefix (<prefix>_<name>, e.g. add_Y_0_ -> add).\n");
+		log("Each cluster is tagged with \\submod and extracted via the submod command.\n");
+		log("\n");
+		log("Used in bitblasted training flows after bus_rebuild so OpenSTA sees one module\n");
+		log("per logical cell. Modules with processes or memories are not supported.\n");
+		log("\n");
+	}
 
 	void execute(std::vector<std::string>, RTLIL::Design *design) override
 	{


### PR DESCRIPTION
## Summary
- Expand `help()` on `obs_clean`, `splitnetlist`, `annotate_cell_fanout`, and `carvenetlist` with algorithms, limitations, and DESIGN-cell caveats previously kept in preqorsor `dev/` markdown.
- Companion preqorsor PR: https://github.com/Silimate/preqorsor/pull/2213

## Test plan
- [x] Spot-check `help obs_clean`, `help splitnetlist`, `help annotate_cell_fanout`, `help carvenetlist` in a local Yosys build
- [x] No functional code changes expected (help text only)