### PR TITLE
opt_shift: add -fuse to merge a modular gather with the shift feeding it

### DIFF
--- a/passes/silimate/opt_shift.cc
+++ b/passes/silimate/opt_shift.cc
@@ -23,6 +23,8 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
+#include "passes/opt/rewrite_utils.h"
+
 bool did_something;
 
 // Driver index for the module being processed, rebuilt per module by the sink
@@ -119,11 +121,185 @@ int min_shift_amount(SigSpec amt, int depth)
   return bound;
 }
 
+// Fuse a modular gather with the variable shift feeding it. opt_vps lowers a
+// bit-select farm to one $shr over its table rotated by a constant and padded
+// with x, so when that table is a shifter output the two barrels sit back to
+// back and -combine cannot merge them: the rotation leaves the outer A port a
+// permutation of the inner Y rather than the same SigSpec.
+//
+//   out[t] = pad_M(x << b)[(t + a + r) % M]
+//     ===>  out[t] = pad_M(x & (~0 >> b))[(t + a + r - b) % M]
+//
+// Masking x drops the high bits the rotate would otherwise wrap in underneath
+// the left shift's zero fill, which is the only place the two disagree. What is
+// left is a single barrel over a repeated source, so one shifter leaves every
+// path through the gather in exchange for a mask that depends on b alone.
+// The shifter itself stays if other cells read it; opt_clean sweeps it if not.
+struct GatherFuser
+{
+  Module *module;
+  SigMap sigmap;
+  dict<SigBit, Cell *> drivers;
+  int max_src_bits;
+  int fused = 0;
+
+  GatherFuser(Module *module, int max_src_bits)
+    : module(module), sigmap(module), max_src_bits(max_src_bits)
+  {
+    for (auto cell : module->cells())
+      for (auto &conn : cell->connections())
+        if (cell->output(conn.first))
+          for (auto bit : sigmap(conn.second))
+            drivers[bit] = cell;
+  }
+
+  // Read `outer`'s A port as one $shl output rotated by a constant: every
+  // defined bit must be inner_y[(j + rot) % mod] for a single rot, and every x
+  // must rotate above inner_y, where it was padding rather than a table entry.
+  Cell *match_rotated_source(Cell *outer, int &rot, int &mod)
+  {
+    SigSpec s = sigmap(outer->getPort(ID::A));
+
+    Cell *inner = nullptr;
+    for (auto bit : s) {
+      if (!bit.is_wire())
+        continue;
+      auto it = drivers.find(bit);
+      if (it == drivers.end() || (inner && it->second != inner))
+        return nullptr;
+      inner = it->second;
+    }
+    if (!inner || inner->type != ID($shl) || inner->getPort(ID::B).is_fully_const())
+      return nullptr;
+    if (inner->getParam(ID::A_SIGNED).as_bool() || inner->getParam(ID::B_SIGNED).as_bool())
+      return nullptr;
+
+    SigSpec iy = sigmap(inner->getPort(ID::Y));
+    int wy = GetSize(iy);
+    if (wy < 2 || wy > (1 << 20)) // keep the table and 1 << clog2 in range
+      return nullptr;
+    mod = 1 << clog2_int(wy);
+    if (GetSize(sigmap(inner->getPort(ID::A))) > mod) // mask is only mod bits wide
+      return nullptr;
+
+    dict<SigBit, int> index;
+    for (int i = 0; i < wy; i++)
+      index.emplace(iy[i], i);
+
+    rot = -1;
+    for (int j = 0; j < GetSize(s); j++) {
+      if (s[j] == State::Sx)
+        continue;
+      auto it = index.find(s[j]);
+      if (it == index.end()) // a defined bit from anywhere but inner_y
+        return nullptr;
+      int r = ((it->second - j) % mod + mod) % mod;
+      if (rot < 0)
+        rot = r;
+      else if (rot != r)
+        return nullptr;
+    }
+    if (rot < 0)
+      return nullptr;
+
+    // An x rotating onto a real inner_y bit was a table entry, not padding
+    for (int j = 0; j < GetSize(s); j++)
+      if (s[j] == State::Sx && (j + rot) % mod < wy)
+        return nullptr;
+
+    return inner;
+  }
+
+  // Largest value an amount can take, discounting constant-zero high bits
+  int max_amount(SigSpec amt)
+  {
+    int w = GetSize(amt);
+    while (w > 0 && amt[w - 1] == State::S0)
+      w--;
+    return w > 20 ? -1 : (1 << w) - 1;
+  }
+
+  void fuse(Cell *outer, Cell *inner, int rot, int mod)
+  {
+    SigSpec x = sigmap(inner->getPort(ID::A));
+    SigSpec b = sigmap(inner->getPort(ID::B));
+    SigSpec a = sigmap(outer->getPort(ID::B));
+    int wx = GetSize(x), wo = outer->getParam(ID::Y_WIDTH).as_int();
+    int amt_bits = clog2_int(mod);
+    std::string src = cell_src(outer);
+
+    // keep[u] = u < mod - b, the positions the left shift did not zero out.
+    // Shifting a constant lowers to a decoder, and it depends only on b, so
+    // the mask costs no depth on the data path.
+    Wire *keep = module->addWire(NEW_ID_SUFFIX("shift_fuse_keep"), mod);
+    module->addShr(NEW_ID_SUFFIX("shift_fuse_keep_shr"), Const(State::S1, mod), b,
+                   SigSpec(keep), false, src);
+    Wire *masked = module->addWire(NEW_ID_SUFFIX("shift_fuse_a"), wx);
+    module->addAnd(NEW_ID_SUFFIX("shift_fuse_and"), x, SigSpec(keep).extract(0, wx),
+                   SigSpec(masked), false, src);
+
+    // amt = (a + rot - b) mod `mod`, wrapped by the amt_bits-wide arithmetic
+    Wire *sum = module->addWire(NEW_ID_SUFFIX("shift_fuse_rot"), amt_bits);
+    module->addAdd(NEW_ID_SUFFIX("shift_fuse_add"), a, const_u64(rot, amt_bits),
+                   SigSpec(sum), false, src);
+    Wire *amt = module->addWire(NEW_ID_SUFFIX("shift_fuse_amt"), amt_bits);
+    module->addSub(NEW_ID_SUFFIX("shift_fuse_sub"), SigSpec(sum), b, SigSpec(amt),
+                   false, src);
+
+    // Repeating the masked source turns the modular access into a plain shift
+    SigSpec period = SigSpec(masked);
+    period.append(SigSpec(State::S0, mod - wx));
+    SigSpec source;
+    while (GetSize(source) < wo + mod - 1)
+      source.append(period);
+    source = source.extract(0, wo + mod - 1);
+
+    log("  shift fuse: %s absorbs %s (M=%d, rot=%d, src=%d bits)\n",
+        log_id(outer->name), log_id(inner->name), mod, rot, GetSize(source));
+
+    // The shifter stays for its other readers; opt_clean sweeps it when the
+    // gather was the only one
+    outer->setPort(ID::A, source);
+    outer->setPort(ID::B, SigSpec(amt));
+    outer->fixup_parameters();
+    fused++;
+  }
+
+  // Fuse at most one gather, so the caller reindexes before looking for more
+  bool run()
+  {
+    for (auto cell : module->selected_cells()) {
+      if (cell->type != ID($shr) || cell->getPort(ID::B).is_fully_const())
+        continue;
+      if (cell->getParam(ID::A_SIGNED).as_bool() || cell->getParam(ID::B_SIGNED).as_bool())
+        continue;
+
+      int rot, mod;
+      Cell *inner = match_rotated_source(cell, rot, mod);
+      if (!inner)
+        continue;
+
+      // A gather that can shift past its source zero-fills there, where the
+      // rotate would instead wrap the table back around
+      int wo = cell->getParam(ID::Y_WIDTH).as_int();
+      int amax = max_amount(sigmap(cell->getPort(ID::B)));
+      if (amax < 0 || wo - 1 + amax >= GetSize(cell->getPort(ID::A)))
+        continue;
+      if (wo + mod - 1 > max_src_bits)
+        continue;
+
+      fuse(cell, inner, rot, mod);
+      return true;
+    }
+    return false;
+  }
+};
+
 #include "passes/silimate/peepopt_shift_pm.h"
 #include "passes/silimate/peepopt_sink_pm.h"
 
 struct OptShiftPass : public Pass {
-  OptShiftPass() : Pass("opt_shift", "shift optimizations: combine and expand") { }
+  OptShiftPass() : Pass("opt_shift", "shift optimizations: combine, expand, sink and fuse") { }
   void help() override
   {
     //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -155,11 +331,25 @@ struct OptShiftPass : public Pass {
     log("      (z >> s) narrower than z. This is the inverse of -expand on\n");
     log("      $add, so the two must not be requested together.\n");
     log("\n");
+    log("  -fuse\n");
+    log("      Fuse a modular gather with the variable left shift feeding it,\n");
+    log("      which -combine cannot do because the gather rotates its table:\n");
+    log("        pad_M(x << b)[(t + a + r) %% M]\n");
+    log("          ===>  pad_M(x & (~0 >> b))[(t + a + r - b) %% M]\n");
+    log("      Masking x replaces the zero fill the rotate would wrap around,\n");
+    log("      so two barrels on the data path become one plus a mask that\n");
+    log("      depends only on b. Only fires when the gather cannot shift past\n");
+    log("      its own source, where it zero-fills but a rotate would wrap.\n");
+    log("\n");
+    log("  -max_fuse_bits n\n");
+    log("      refuse a -fuse rewrite whose repeated source would exceed n\n");
+    log("      bits (default 4096).\n");
+    log("\n");
     log("  -max_iters n\n");
     log("      max number of pass iterations to run.\n");
     log("\n");
-    log("If none of -combine, -expand or -sink is given, combine and expand\n");
-    log("are run.\n");
+    log("If none of -combine, -expand, -sink or -fuse is given, combine and\n");
+    log("expand are run.\n");
     log("\n");
   }
   void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -169,6 +359,8 @@ struct OptShiftPass : public Pass {
     bool run_combine = false;
     bool run_expand = false;
     bool run_sink = false;
+    bool run_fuse = false;
+    int max_fuse_bits = 4096;
     int max_iters = 10000;
 
     size_t argidx;
@@ -185,6 +377,14 @@ struct OptShiftPass : public Pass {
         run_sink = true;
         continue;
       }
+      if (args[argidx] == "-fuse") {
+        run_fuse = true;
+        continue;
+      }
+      if (args[argidx] == "-max_fuse_bits" && argidx + 1 < args.size()) {
+        max_fuse_bits = std::stoi(args[++argidx]);
+        continue;
+      }
       if (args[argidx] == "-max_iters" && argidx + 1 < args.size()) {
         max_iters = std::stoi(args[++argidx]);
         continue;
@@ -193,7 +393,7 @@ struct OptShiftPass : public Pass {
     }
     extra_args(args, argidx, design);
 
-    if (!run_combine && !run_expand && !run_sink) {
+    if (!run_combine && !run_expand && !run_sink && !run_fuse) {
       run_combine = true;
       run_expand = true;
     }
@@ -202,6 +402,7 @@ struct OptShiftPass : public Pass {
     if (run_expand && run_sink)
       log_cmd_error("opt_shift: -expand and -sink are inverses, pick one.\n");
 
+    int total_fused = 0;
     for (auto module : design->selected_modules())
     {
       did_something = true;
@@ -224,8 +425,17 @@ struct OptShiftPass : public Pass {
           pm.setup(module->selected_cells());
           pm.run_sink_shifts();
         }
+        // Same pre-filter: a gather only fuses with a variable-amount shifter
+        if (run_fuse && has_variable_shift(module)) {
+          GatherFuser fuser(module, max_fuse_bits);
+          did_something |= fuser.run();
+          total_fused += fuser.fused;
+        }
       }
     }
+
+    if (run_fuse)
+      log("Fused %d gather(s) with the shift feeding them.\n", total_fused);
   }
 } OptShiftPass;
 

--- a/tests/silimate/opt_fuse_shifts.ys
+++ b/tests/silimate/opt_fuse_shifts.ys
@@ -1,0 +1,168 @@
+log -header "Rotated gather over a variable left shift: one barrel plus an input mask"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [15:0] x,
+  input wire [3:0]  b,
+  input wire [2:0]  a,
+  output wire [7:0] y
+);
+  wire [15:0] sh  = x << b;
+  // opt_vps emits its gather source rotated, which is why -combine cannot see
+  // through this: the outer A port is a permutation of sh, not sh itself
+  wire [15:0] rot = {sh[6:0], sh[15:7]};
+  assign y = rot >> a;
+endmodule
+EOF
+prep -top top
+check -assert
+select -assert-count 1 t:$shl
+equiv_opt -assert opt_shift -fuse
+design -load postopt
+opt_clean
+# the left shift is gone: the gather was its only reader
+select -assert-count 0 t:$shl
+# the surviving barrel, plus the constant shift forming the keep mask
+select -assert-count 2 t:$shr
+select -assert-count 1 t:$and
+# amt = a + rot - b
+select -assert-count 1 t:$add
+select -assert-count 1 t:$sub
+design -reset
+log -pop
+
+
+
+log -header "Table padded with x above the shifter output, as opt_vps leaves it"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [15:0] x,
+  input wire [3:0]  b,
+  input wire [2:0]  a,
+  output wire [7:0] y
+);
+  wire [11:0] sh  = x << b;
+  // 12 real entries rotated by 5 into a 16-entry table; the four x are the
+  // out-of-range reads, which must land above sh rather than on a real bit
+  wire [15:0] rot = {sh[4:0], 4'bx, sh[11:5]};
+  assign y = rot >> a;
+endmodule
+EOF
+prep -top top
+check -assert
+select -assert-count 1 t:$shl
+equiv_opt -undef -assert opt_shift -fuse
+design -load postopt
+opt_clean
+select -assert-count 0 t:$shl
+select -assert-count 1 t:$and
+design -reset
+log -pop
+
+
+
+log -header "Negative: a gather that can shift past its source zero-fills, a rotate wraps"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [15:0] x,
+  input wire [3:0]  b,
+  input wire [3:0]  a,
+  output wire [7:0] y
+);
+  wire [15:0] sh  = x << b;
+  wire [15:0] rot = {sh[6:0], sh[15:7]};
+  // a reaches 15, so y[7] can read past bit 15 and must come back zero
+  assign y = rot >> a;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -fuse
+design -load postopt
+select -assert-count 1 t:$shl
+select -assert-count 0 t:$and
+design -reset
+log -pop
+
+
+
+log -header "Negative: constant inner amount is rewiring that -combine already folds"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [15:0] x,
+  input wire [2:0]  a,
+  output wire [7:0] y
+);
+  wire [15:0] sh  = x << 3;
+  wire [15:0] rot = {sh[6:0], sh[15:7]};
+  assign y = rot >> a;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -fuse
+design -load postopt
+# no mask, because there is no variable amount to mask against
+select -assert-count 0 t:$and
+select -assert-count 0 t:$sub
+design -reset
+log -pop
+
+
+
+log -header "Negative: signed operands are outside the unsigned rewrite"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire signed [15:0] x,
+  input wire [3:0]  b,
+  input wire [2:0]  a,
+  output wire signed [7:0] y
+);
+  wire signed [15:0] sh  = x <<< b;
+  wire signed [15:0] rot = {sh[6:0], sh[15:7]};
+  assign y = rot >>> a;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -fuse
+design -load postopt
+select -assert-count 0 t:$and
+design -reset
+log -pop
+
+
+
+log -header "Negative: the source is not one shifter permuted, so there is no single rot"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [15:0] x,
+  input wire [3:0]  b,
+  input wire [2:0]  a,
+  output wire [7:0] y
+);
+  wire [15:0] sh  = x << b;
+  // half the table comes straight from x, so the gather is not a rotation of sh
+  wire [15:0] rot = {sh[6:0], x[15:7]};
+  assign y = rot >> a;
+endmodule
+EOF
+prep -top top
+check -assert
+equiv_opt -assert opt_shift -fuse
+design -load postopt
+select -assert-count 1 t:$shl
+select -assert-count 0 t:$and
+design -reset
+log -pop


### PR DESCRIPTION
## Summary

Adds `opt_shift -fuse`, which collapses two variable barrels in series that `-combine` structurally cannot see through.

`opt_vps` lowers a bit-select farm to one `$shr` over its table rotated by a constant and padded with `x`. When that table is a variable shift's output, the two barrels sit back to back, and `-combine` requires the outer `A` port to *be* the inner `Y` — the rotation makes it a permutation instead.

Relaxing that match to accept a constant reindex is **not** sound. The wrapped entries are reachable (on the motivating design, `w_mid = 0, off_a = 15, i = 1` reads a real bit of the table through the wrap), so the mod has to be preserved and the two amounts cannot simply add.

Trading the zero fill for a mask does work:

```
out[t] = pad_M(x << b)[(t + a + r) % M]
  ===>  out[t] = pad_M(x & (~0 >> b))[(t + a + r - b) % M]
```

The two forms differ only where the rotate wraps a high bit of `x` in underneath the left shift's zero fill, and masking `x` kills exactly those bits. What is left is one barrel over a repeated source plus a mask that depends on `b` alone, so it lowers to a decoder rather than a barrel and costs no data-path depth.

### Guards

- Refuses when the gather can shift past its own source, where it zero-fills but a rotate would wrap.
- Every defined `A` bit must be `inner_y[(j + rot) % M]` for a single `rot`, and every `x` must rotate above `inner_y`, where it was padding rather than a table entry.
- Inner must be an unsigned `$shl` with a non-constant amount; a constant one is already rewiring that `-combine` folds.
- `-max_fuse_bits` (default 4096) bounds the repeated source.

The shifter is left in place for any other readers; `opt_clean` sweeps it when the gather was its only consumer.

## Test plan

Measured through Preqorsor on `qor_dyn_bitfield_align` (companion PR adds `-fuse` to the flow and the regression assertions):

- [x] LoL 33.25 -> 31.25, area 564.8 -> 554.6
- [x] The rewrite identity checked exhaustively against the reference semantics over the design's exact geometry plus five perturbed shapes
- [x] Formal mode wraps the pass in `equiv_opt -undef -ignore-unknown-cells -post -assert`; **the fusion's own equivalence check passes**. The later pre-existing unproven cells drop from 6 to 3 with the change
- [x] Full Preqorsor regression: 311 passed, 8 xfailed. Two failures are worktree setup artifacts (uninitialized submodule; a prebuilt `silisizer` lacking `write_lib_db`), and neither design sees a fusion, so their netlists are identical to baseline
- [x] Fires exactly once across all 321 regression run logs, on the target design only
- [x] Negative near-miss (`qor_dyn_bitfield_align_novar`, in the companion PR): same cone with a constant align shift, asserts `Fused 0 gather(s)`

Made with [Cursor](https://cursor.com)