### PR TITLE
techlibs/common: fix cmp2softlogic polarity, support signed compares

### DIFF
--- a/techlibs/common/cmp2softlogic.v
+++ b/techlibs/common/cmp2softlogic.v
@@ -1,3 +1,10 @@
+// A comparison against a constant does not need a generic (carry-chain) comparator: each
+// constant bit decides whether the running result is extended with an AND or an OR of the
+// corresponding variable bit, so the whole compare folds into an AND/OR chain that
+// downstream logic optimization can rebalance into log depth.
+
+// Y = (A >= B) when C is 1, (A > B) when C is 0. B is expected to be constant, which folds
+// each mux below into a single AND (for B[n] = 1) or OR (for B[n] = 0).
 module constgtge(C, A, B, Y);
 parameter A_WIDTH = 0;
 parameter B_WIDTH = 0;
@@ -28,6 +35,7 @@ generate
 endgenerate
 endmodule
 
+// Y = (A <= B) when C is 1, (A < B) when C is 0: constgtge over inverted operands.
 module constltle(C, A, B, Y);
 parameter A_WIDTH = 0;
 parameter B_WIDTH = 0;
@@ -82,33 +90,51 @@ parameter _TECHMAP_CONSTVAL_B_ = 0;
 
 wire [1023:0] _TECHMAP_DO_ = "opt -fast;";
 
-wire [A_WIDTH:0] ch;
+// The comparison is signed only when both operands are; mixed signedness is unsigned
+localparam SGN = A_SIGNED && B_SIGNED;
+// Compare at the wider width, so either operand may be the narrower one
+localparam W = A_WIDTH > B_WIDTH ? A_WIDTH : B_WIDTH;
 
-genvar n;
+wire [W-1:0] Aext, Bext, bias, Ab, Bb;
+
 generate
-	if (Y_WIDTH != 1 || A_SIGNED || B_SIGNED)
+	if (SGN) begin
+		// Flipping the sign bit turns two's-complement order into unsigned order, so the
+		// unsigned chains below cover signed compares too
+		assign Aext = $signed(A);
+		assign Bext = $signed(B);
+		assign bias = 1 << (W - 1);
+	end else begin
+		assign Aext = A;
+		assign Bext = B;
+		assign bias = 0;
+	end
+endgenerate
+
+assign Ab = Aext ^ bias;
+assign Bb = Bext ^ bias;
+
+generate
+	if (Y_WIDTH != 1)
 		wire _TECHMAP_FAIL_ = 1;
-	else if (&_TECHMAP_CONSTMSK_A_) begin
-		if (A_WIDTH > B_WIDTH)
-			wire _TECHMAP_FAIL_ = 1;
-		else if (_TECHMAP_CELLTYPE_ == "$lt" || _TECHMAP_CELLTYPE_ == "$le")
-			constgtge #(.A_WIDTH(B_WIDTH), .B_WIDTH(A_WIDTH))
-				_TECHMAP_REPLACE_(.A(B), .B(A), .Y(Y),
-					.C(_TECHMAP_CELLTYPE_ == "$lt"));
-		else
-			constltle #(.A_WIDTH(B_WIDTH), .B_WIDTH(A_WIDTH))
-				_TECHMAP_REPLACE_(.A(B), .B(A), .Y(Y),
-					.C(_TECHMAP_CELLTYPE_ == "$gt"));
-	end else if (&_TECHMAP_CONSTMSK_B_) begin
-		if (B_WIDTH > A_WIDTH)
-			wire _TECHMAP_FAIL_ = 1;
-		else if (_TECHMAP_CELLTYPE_ == "$lt" || _TECHMAP_CELLTYPE_ == "$le")
-			constltle #(.A_WIDTH(A_WIDTH), .B_WIDTH(B_WIDTH))
-				_TECHMAP_REPLACE_(.A(A), .B(B), .Y(Y),
+	else if (&_TECHMAP_CONSTMSK_B_) begin
+		if (_TECHMAP_CELLTYPE_ == "$lt" || _TECHMAP_CELLTYPE_ == "$le")
+			constltle #(.A_WIDTH(W), .B_WIDTH(W))
+				_TECHMAP_REPLACE_(.A(Ab), .B(Bb), .Y(Y),
 					.C(_TECHMAP_CELLTYPE_ == "$le"));
 		else
-			constgtge #(.A_WIDTH(A_WIDTH), .B_WIDTH(B_WIDTH))
-				_TECHMAP_REPLACE_(.A(A), .B(B), .Y(Y),
+			constgtge #(.A_WIDTH(W), .B_WIDTH(W))
+				_TECHMAP_REPLACE_(.A(Ab), .B(Bb), .Y(Y),
+					.C(_TECHMAP_CELLTYPE_ == "$ge"));
+	end else if (&_TECHMAP_CONSTMSK_A_) begin
+		// Constant on A: swap the operands and mirror the operator, as A < B is B > A
+		if (_TECHMAP_CELLTYPE_ == "$lt" || _TECHMAP_CELLTYPE_ == "$le")
+			constgtge #(.A_WIDTH(W), .B_WIDTH(W))
+				_TECHMAP_REPLACE_(.A(Bb), .B(Ab), .Y(Y),
+					.C(_TECHMAP_CELLTYPE_ == "$le"));
+		else
+			constltle #(.A_WIDTH(W), .B_WIDTH(W))
+				_TECHMAP_REPLACE_(.A(Bb), .B(Ab), .Y(Y),
 					.C(_TECHMAP_CELLTYPE_ == "$ge"));
 	end else
 		wire _TECHMAP_FAIL_ = 1;

--- a/tests/techmap/cmp2softlogic.ys
+++ b/tests/techmap/cmp2softlogic.ys
@@ -5,7 +5,10 @@ module top(
 	input  signed [11:0] s,
 	input  [0:0]  u1,
 	input  signed [0:0] s1,
-	output [16:0] y
+	input  signed [39:0] s40,
+	input  signed [63:0] s64,
+	input  [39:0] u40,
+	output [20:0] y
 );
 	// Unsigned, constant on B
 	assign y[0] = u <  12'd700;
@@ -28,8 +31,14 @@ module top(
 	// Single-bit operands, where the signed bias is the whole value
 	assign y[14] = u1 >= 1'd1;
 	assign y[15] = s1 <  -1'sd1;
+	// Wider than the 32-bit unsized literal that builds the signed bias, so a bias that
+	// silently truncated to zero would leave these compared as unsigned
+	assign y[16] = s40 <  -40'sd5;
+	assign y[17] = s40 >=  40'sd300000000000;
+	assign y[18] = -64'sd5 <  s64;
+	assign y[19] = u40 >  40'd700;
 	// Neither operand constant: must be left for the generic comparator path
-	assign y[16] = u > v;
+	assign y[20] = u > v;
 endmodule
 EOT
 
@@ -40,14 +49,14 @@ opt_clean
 
 # Every compare above is a distinct cell at this point, so the counts below pin down
 # exactly which ones the map file claims
-select -assert-count 5 t:$lt
+select -assert-count 7 t:$lt
 select -assert-count 3 t:$le
-select -assert-count 4 t:$gt
-select -assert-count 5 t:$ge
+select -assert-count 5 t:$gt
+select -assert-count 6 t:$ge
 
 equiv_opt -assert techmap -map +/cmp2softlogic.v
 design -load postopt
 
-# All 16 constant-operand compares are mapped; only the variable-variable $gt survives
+# All 20 constant-operand compares are mapped; only the variable-variable $gt survives
 select -assert-count 0 t:$lt t:$le t:$ge
 select -assert-count 1 t:$gt

--- a/tests/techmap/cmp2softlogic.ys
+++ b/tests/techmap/cmp2softlogic.ys
@@ -1,0 +1,53 @@
+read_verilog <<EOT
+module top(
+	input  [11:0] u,
+	input  [11:0] v,
+	input  signed [11:0] s,
+	input  [0:0]  u1,
+	input  signed [0:0] s1,
+	output [16:0] y
+);
+	// Unsigned, constant on B
+	assign y[0] = u <  12'd700;
+	assign y[1] = u <= 12'd700;
+	assign y[2] = u >  12'd700;
+	assign y[3] = u >= 12'd700;
+	// Unsigned, constant on A
+	assign y[4] = 12'd700 <  u;
+	assign y[5] = 12'd700 <= u;
+	assign y[6] = 12'd700 >  u;
+	assign y[7] = 12'd700 >= u;
+	// Signed, constant on B, negative and positive thresholds
+	assign y[8]  = s <  -12'sd5;
+	assign y[9]  = s <= -12'sd5;
+	assign y[10] = s >   12'sd300;
+	assign y[11] = s >=  12'sd300;
+	// Signed, constant on A
+	assign y[12] = -12'sd5 <  s;
+	assign y[13] = -12'sd5 >= s;
+	// Single-bit operands, where the signed bias is the whole value
+	assign y[14] = u1 >= 1'd1;
+	assign y[15] = s1 <  -1'sd1;
+	// Neither operand constant: must be left for the generic comparator path
+	assign y[16] = u > v;
+endmodule
+EOT
+
+proc
+opt_expr
+wreduce
+opt_clean
+
+# Every compare above is a distinct cell at this point, so the counts below pin down
+# exactly which ones the map file claims
+select -assert-count 5 t:$lt
+select -assert-count 3 t:$le
+select -assert-count 4 t:$gt
+select -assert-count 5 t:$ge
+
+equiv_opt -assert techmap -map +/cmp2softlogic.v
+design -load postopt
+
+# All 16 constant-operand compares are mapped; only the variable-variable $gt survives
+select -assert-count 0 t:$lt t:$le t:$ge
+select -assert-count 1 t:$gt


### PR DESCRIPTION
## Summary

`cmp2softlogic.v` lowers a comparison against a constant into an AND/OR chain instead of a
generic comparator. Two problems:

- The constant-on-A branch seeded the chain from the original operator rather than the mirrored
  one, so it computed `<` for `<=` and `>` for `>=` (and vice versa) whenever the constant landed
  on A. That is the common case after `wreduce`, which normalizes the constant onto the narrower
  operand, so this is not a corner case: a formal run over a design using `<=` against a constant
  came back with thousands of unproven equivalence cells.
- Signed operands, and a constant wider than the variable, were both bailed out of. Comparing at
  the wider width and flipping the sign bit (which turns two's-complement order into unsigned
  order) lets those map too. The existing `_TECHMAP_DO_ = "opt -fast;"` folds the bias XOR away,
  so the operand still looks constant to the chain.

Comparisons of two variables are still declined and left for the generic comparator path.

## Test plan

- [x] New `tests/techmap/cmp2softlogic.ys` proves equivalence with `equiv_opt -assert` over all
      four operators x constant on either side x signed/unsigned, plus 1-bit operands where the
      sign bias is the whole value: `Equivalence successfully proven!`
- [x] Same test asserts the variable-variable `$gt` survives the map, and pins the pre-map cell
      counts so the mapped set cannot silently shrink.
- [x] Verified the old file fails this test in the constant-on-A cases, i.e. the test actually
      covers the bug.

Made with [Cursor](https://cursor.com)