### PR TITLE
opt_disjoint_add: rewrite non-overlapping adds as $or; arith_tree: per-chain -min-width

### DIFF
--- a/passes/opt/CMakeLists.txt
+++ b/passes/opt/CMakeLists.txt
@@ -132,6 +132,10 @@ yosys_pass(opt_mux_odc
 	opt_mux_odc.cc
 )
 
+yosys_pass(opt_disjoint_add
+	opt_disjoint_add.cc
+)
+
 pmgen_command(peepopt
 	peepopt_shiftmul_right.pmg
 	peepopt_shiftmul_left.pmg

--- a/passes/opt/opt_disjoint_add.cc
+++ b/passes/opt/opt_disjoint_add.cc
@@ -1,0 +1,372 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2026  Silimate Inc.     <akash@silimate.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+#include "kernel/consteval.h"
+#include <queue>
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+#include "passes/opt/cut_region.h"
+
+struct OptDisjointAddWorker : CutRegionWorker
+{
+	struct Rewrite {
+		Cell *add;
+		SigSpec shifted;  // operand whose low `amount` bits are zero
+		SigSpec addend;   // operand proven to fit below that window
+		SigSpec y;
+		int width;
+		int cases;        // enumerated support assignments (for the log)
+	};
+
+	// Enumeration is exponential in the joint support, so the cap is the
+	// pass's main cost knob: 2^max_support_bits ConstEval sweeps per
+	// candidate, each charged against the shared eval budget.
+	int max_support_bits = 16;
+	int max_cone_cells = 4000;
+
+	vector<Rewrite> rewrites;
+	int skipped_roots = 0;
+
+	OptDisjointAddWorker(Module *module) : CutRegionWorker(module)
+	{
+	}
+
+	// $shl driving `operand`, else null. The shift's own data operand is
+	// deliberately not inspected: bit i of (X << s) is zero for every i < s
+	// whatever X is, which is the only fact the proof needs.
+	Cell *shl_driver(const SigSpec &operand)
+	{
+		SigSpec sig = sigmap(operand);
+		if (sig.empty())
+			return nullptr;
+
+		Cell *drv = bit_to_driver.at(sig[0], nullptr);
+		if (drv == nullptr || drv->type != ID($shl))
+			return nullptr;
+
+		// Every operand bit must come from that $shl's Y, in order, from bit
+		// 0 up; trailing zero padding is fine (a widened use of the shift).
+		SigSpec y = sigmap(drv->getPort(ID::Y));
+		for (int i = 0; i < GetSize(sig); i++) {
+			if (i < GetSize(y)) {
+				if (sig[i] != y[i])
+					return nullptr;
+			} else if (sig[i] != SigBit(State::S0)) {
+				return nullptr;
+			}
+		}
+		return drv;
+	}
+
+	// Shift amount opening the window at the bottom of `operand`: the $shl's
+	// amount if one drives it, else the run of literal zero bits there. A
+	// constant shift is folded away long before this pass runs, so that form
+	// arrives as an operand zero-padded at the bottom rather than as a cell.
+	bool window_amount(const SigSpec &operand, SigSpec &amount)
+	{
+		Cell *shl = shl_driver(operand);
+		if (shl != nullptr) {
+			if (shl->getParam(ID::B_SIGNED).as_bool())
+				return false;
+			amount = sigmap(shl->getPort(ID::B));
+			return true;
+		}
+
+		int zeros = 0;
+		while (zeros < GetSize(operand) && operand[zeros] == SigBit(State::S0))
+			zeros++;
+		if (zeros == 0)
+			return false;
+		amount = const_u64((uint64_t)zeros, 32);
+		return true;
+	}
+
+	// True when every bit of `sig` from `from` up is a literal zero.
+	static bool zero_above(const SigSpec &sig, int from)
+	{
+		for (int i = std::max(from, 0); i < GetSize(sig); i++)
+			if (sig[i] != SigBit(State::S0))
+				return false;
+		return true;
+	}
+
+	// Leaves of the combinational cone behind `sig`, added to `support`.
+	// `cone_size` accumulates cell counts so the sweep can be charged for
+	// what a ConstEval pass over these cones actually costs.
+	bool collect_support(const SigSpec &sig, pool<SigBit> &support, int &cone_size)
+	{
+		pool<Cell *> cone_cells;
+		pool<SigBit> leaves;
+		if (!get_cone(sig, cone_cells, leaves, max_cone_cells, max_support_bits))
+			return false;
+		for (auto bit : leaves)
+			support.insert(bit);
+		cone_size += GetSize(cone_cells);
+		return GetSize(support) <= max_support_bits;
+	}
+
+	// Value of a fully-defined shift amount, clamped to `clamp`. A $shl by
+	// more than the operand width zeroes the whole result, so clamping an
+	// out-of-int amount stays conservative instead of overflowing.
+	static int shift_amount_value(const Const &amount, int clamp)
+	{
+		for (int i = 30; i < GetSize(amount); i++)
+			if (amount[i] == State::S1)
+				return clamp;
+
+		int value = 0;
+		for (int i = 0; i < GetSize(amount) && i < 30; i++)
+			if (amount[i] == State::S1)
+				value |= 1 << i;
+		return value;
+	}
+
+	// Sweep every assignment of `support` and require the addend to stay
+	// strictly below the shift window on all of them. Both signals are
+	// evaluated under the same assignment, so amounts and magnitudes that
+	// share drivers (a shift by f(k) paired with an addend bounded by g(k))
+	// are proven jointly rather than by independent per-operand ranges.
+	bool prove_disjoint(const SigSpec &amount, const SigSpec &addend,
+	                    const pool<SigBit> &support, int cone_size, int &cases)
+	{
+		SigSpec support_sig;
+		for (auto bit : support)
+			support_sig.append(bit);
+
+		int n = GetSize(support_sig);
+		if (n > max_support_bits || n >= 31)
+			return false;
+
+		cases = 1 << n;
+		charge_eval((int64_t)cases * std::max(cone_size, 1));
+		if (eval_exhausted())
+			return false;
+
+		ConstEval ce(module);
+		for (int v = 0; v < cases; v++) {
+			ce.push();
+			ce.set(support_sig, const_u64((uint64_t)v, n));
+
+			SigSpec amount_val = amount, addend_val = addend, undef;
+			bool ok = ce.eval(amount_val, undef) && ce.eval(addend_val, undef);
+			ce.pop();
+
+			// An x bit (or an unresolved one, meaning the support was
+			// under-collected) proves nothing about this assignment. Rejecting
+			// x keeps the rewrite independent of don't-care freedom.
+			if (!ok || !amount_val.is_fully_def() || !addend_val.is_fully_def())
+				return false;
+
+			Const addend_const = addend_val.as_const();
+			int shift = shift_amount_value(amount_val.as_const(), GetSize(addend_const));
+			for (int i = shift; i < GetSize(addend_const); i++)
+				if (addend_const[i] != State::S0)
+					return false;
+		}
+		return true;
+	}
+
+	void collect(Cell *cell)
+	{
+		if (cell->type != ID($add))
+			return;
+		if (cell->getParam(ID::A_SIGNED).as_bool() || cell->getParam(ID::B_SIGNED).as_bool())
+			return;
+
+		int width = cell->getParam(ID::Y_WIDTH).as_int();
+		if (width < 2)
+			return;
+
+		SigSpec ports[2] = {sigmap(cell->getPort(ID::A)), sigmap(cell->getPort(ID::B))};
+		for (int side = 0; side < 2; side++) {
+			SigSpec amount;
+			if (!window_amount(ports[side], amount))
+				continue;
+			SigSpec addend = ports[1 - side];
+
+			// A fixed window that the addend structurally fits under needs no
+			// sweep, and so carries no bound on the addend's cone either.
+			if (amount.is_fully_def() &&
+			    zero_above(addend, shift_amount_value(amount.as_const(), GetSize(addend)))) {
+				log_debug("  %s: addend is structurally below a fixed window\n", log_id(cell));
+				rewrites.push_back({cell, ports[side], addend, sigmap(cell->getPort(ID::Y)),
+				                    width, 0});
+				return;
+			}
+
+			if (walk_exhausted() || eval_exhausted()) {
+				skipped_roots++;
+				return;
+			}
+
+			pool<SigBit> support;
+			int cone_size = 0;
+			if (!collect_support(amount, support, cone_size) ||
+			    !collect_support(addend, support, cone_size)) {
+				log_debug("  %s: joint support of %s / %s exceeds %d bits\n",
+				          log_id(cell), log_signal(amount), log_signal(addend), max_support_bits);
+				continue;
+			}
+
+			int cases = 0;
+			if (!prove_disjoint(amount, addend, support, cone_size, cases)) {
+				log_debug("  %s: operands may overlap (support %d bits)\n",
+				          log_id(cell), GetSize(support));
+				continue;
+			}
+
+			log_debug("  %s: disjoint over %d case(s), %d support bit(s)\n",
+			          log_id(cell), cases, GetSize(support));
+			rewrites.push_back({cell, ports[side], addend, sigmap(cell->getPort(ID::Y)),
+			                    width, cases});
+			return;
+		}
+	}
+
+	void apply(const Rewrite &rewrite)
+	{
+		Cell *cell = rewrite.add;  // NEW_ID2_SUFFIX names the $or after it
+
+		SigSpec a = rewrite.shifted, b = rewrite.addend;
+		a.extend_u0(rewrite.width, false);
+		b.extend_u0(rewrite.width, false);
+
+		Cell *or_cell = module->addCell(NEW_ID2_SUFFIX("disjoint_or"), ID($or));
+		or_cell->attributes = cell->attributes;
+		or_cell->setPort(ID::A, a);
+		or_cell->setPort(ID::B, b);
+		or_cell->setPort(ID::Y, rewrite.y);
+		or_cell->setParam(ID::A_SIGNED, false);
+		or_cell->setParam(ID::B_SIGNED, false);
+		or_cell->fixup_parameters();
+
+		module->remove(cell);
+	}
+
+	int run()
+	{
+		vector<Cell *> cells;
+		for (auto cell : module->selected_cells())
+			cells.push_back(cell);
+		for (auto cell : cells)
+			collect(cell);
+
+		for (auto &rewrite : rewrites)
+			apply(rewrite);
+
+		note_budget("opt_disjoint_add", skipped_roots);
+		return GetSize(rewrites);
+	}
+};
+
+struct OptDisjointAddPass : public Pass {
+	OptDisjointAddPass() : Pass("opt_disjoint_add", "rewrite non-overlapping adds as bitwise or") { }
+
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    opt_disjoint_add [options] [selection]\n");
+		log("\n");
+		log("Replace an $add whose two operands can never hold a 1 in the same bit\n");
+		log("position with a plain $or. Such an add carries nowhere, so the adder is a\n");
+		log("full carry-propagate network computing a concatenation:\n");
+		log("\n");
+		log("    (X << s) + b    ->    (X << s) | b        when b < 2**s always\n");
+		log("\n");
+		log("The idiom shows up in address generation, where a coarse field is scaled\n");
+		log("by a run-time shift and a fine field is dropped into the hole underneath\n");
+		log("it. Both are usually derived from the same control register, so the two\n");
+		log("operands are only provably non-overlapping when the shift amount and the\n");
+		log("addend magnitude are considered together -- independent per-operand range\n");
+		log("analysis sees the windows touch and gives up.\n");
+		log("\n");
+		log("The match therefore takes the combinational cone leaves behind the shift\n");
+		log("amount and behind the addend, sweeps every assignment of that joint\n");
+		log("support with ConstEval, and requires the addend to stay below the shift\n");
+		log("window on all of them. The shift's data operand is never inspected: bit i\n");
+		log("of (X << s) is zero for all i < s regardless of X, so its cone (typically\n");
+		log("the wide datapath) neither has to be enumerated nor bounded.\n");
+		log("\n");
+		log("A constant shift is folded away before this pass runs, so that case\n");
+		log("arrives as an operand carrying literal zeros at the bottom. It is taken\n");
+		log("directly from the operand shapes when the addend is short enough, with no\n");
+		log("sweep and hence no limit on how wide the addend's cone may be.\n");
+		log("\n");
+		log("Signed operands, a signed shift amount, and any assignment that ConstEval\n");
+		log("cannot resolve are all rejected, as is a joint support wider than\n");
+		log("-max-support (the sweep is exponential in it).\n");
+		log("\n");
+		log("    -max-support <n>\n");
+		log("        maximum joint support width to enumerate (default 16, so up to\n");
+		log("        65536 sweeps per candidate). Candidates above this are skipped.\n");
+		log("\n");
+		log("    -max-cone-cells <n>\n");
+		log("        maximum cells per collected cone (default 4000).\n");
+		log("\n");
+		log("    -eval-budget <n>\n");
+		log("        per-module ConstEval work budget (default 20000000).\n");
+		log("\n");
+	}
+
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing OPT_DISJOINT_ADD pass (non-overlapping add to or).\n");
+
+		int max_support_bits = 16, max_cone_cells = 4000;
+		int64_t eval_budget = -1;
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			if (args[argidx] == "-max-support" && argidx + 1 < args.size()) {
+				max_support_bits = atoi(args[++argidx].c_str());
+				continue;
+			}
+			if (args[argidx] == "-max-cone-cells" && argidx + 1 < args.size()) {
+				max_cone_cells = atoi(args[++argidx].c_str());
+				continue;
+			}
+			if (args[argidx] == "-eval-budget" && argidx + 1 < args.size()) {
+				eval_budget = std::stoll(args[++argidx]);
+				continue;
+			}
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		int total = 0;
+		for (auto module : design->selected_modules()) {
+			OptDisjointAddWorker worker(module);
+			worker.max_support_bits = max_support_bits;
+			worker.max_cone_cells = max_cone_cells;
+			if (eval_budget > 0)
+				worker.eval_budget = eval_budget;
+			total += worker.run();
+		}
+
+		if (total)
+			design->scratchpad_set_bool("opt.did_something", true);
+		log("Rewrote %d non-overlapping add%s into $or.\n", total, total == 1 ? "" : "s");
+	}
+} OptDisjointAddPass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/techmap/arith_tree.cc
+++ b/passes/techmap/arith_tree.cc
@@ -21,6 +21,9 @@ struct ArithTreeOptions {
 	CompressorTree::Strategy strategy = CompressorTree::Strategy::PREFER_42;
 	CompressorTree::FinalMode final_mode = CompressorTree::FinalMode::RIPPLE;
 	bool fma_fusion = true;
+	// A compressor level costs roughly fixed depth at any width, so
+	// compression only pays when it removes a wide carry-propagate adder.
+	int min_width = 0;
 };
 
 struct ArithTreeWorker {
@@ -364,6 +367,9 @@ struct ArithTreeWorker {
 			if (has_parent.count(root) || to_remove.count(root))
 				continue; // Not a tree root
 
+			if (GetSize(root->getPort(ID::Y)) < opt.min_width)
+				continue;
+
 			pool<Cell *> chain = collect_chain(root, children_of);
 			if (chain.size() < 2)
 				continue;
@@ -387,6 +393,9 @@ struct ArithTreeWorker {
 	{
 		pool<Cell *> to_remove;
 		for (auto cell : macc) {
+			if (GetSize(cell->getPort(ID::Y)) < opt.min_width)
+				continue;
+
 			std::vector<Operand> operands;
 			int neg_compensation;
 			if (!extract_macc_operands(cell, operands, neg_compensation))
@@ -443,6 +452,16 @@ struct ArithTreePass : public Pass {
 		log("    -no-fma\n");
 		log("        Disable fused multiply-add expansion in $macc cells\n");
 		log("\n");
+		log("    -min-width <n>\n");
+		log("        Skip chains and $macc cells whose result is narrower than <n>\n");
+		log("        bits (default 0, i.e. no limit). A compressor level costs about\n");
+		log("        the same depth at any width, so compression only pays when it\n");
+		log("        removes a wide carry-propagate adder; below that the plain chain\n");
+		log("        (or 'opt_balance_tree') wins. Prefer this over restricting the\n");
+		log("        selection: this pass indexes every cell in a selected module, so\n");
+		log("        a cell-level selection only gates which modules run, and one wide\n");
+		log("        adder anywhere would otherwise pull in all the narrow chains too.\n");
+		log("\n");
 		log("The default behaviour delivers 4:2 compression, FMA fusion, and a\n");
 		log("final standard adder\n");
 		log("\n");
@@ -474,6 +493,10 @@ struct ArithTreePass : public Pass {
 			}
 			if (arg == "-no-fma") {
 				opt.fma_fusion = false;
+				continue;
+			}
+			if (arg == "-min-width" && argidx + 1 < args.size()) {
+				opt.min_width = atoi(args[++argidx].c_str());
 				continue;
 			}
 			break;

--- a/tests/arith_tree/arith_tree_min_width.ys
+++ b/tests/arith_tree/arith_tree_min_width.ys
@@ -1,0 +1,92 @@
+# -min-width gates each chain on its own result width.
+#
+# The limit used to be applied by restricting the selection, which does not
+# work: the pass indexes every cell of a selected module, so a cell-level
+# selection only chooses which modules run. These tests pin the per-chain
+# behaviour, including the mixed-width module where the two rules differ.
+
+# A narrow chain is left alone above its width...
+read_verilog <<EOT
+module narrow(
+	input [7:0] a, b, c,
+	output [7:0] y
+);
+	assign y = a + b + c;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+arith_tree -min-width 16
+select -assert-none t:$fa
+select -assert-count 2 t:$add
+design -reset
+
+# ...and compressed once the limit admits it.
+read_verilog <<EOT
+module narrow(
+	input [7:0] a, b, c,
+	output [7:0] y
+);
+	assign y = a + b + c;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+arith_tree -min-width 8
+select -assert-min 1 t:$fa
+design -reset
+
+# A wide chain next to a narrow one: only the wide chain compresses. Under a
+# selection-based limit the whole module would qualify and both would.
+read_verilog <<EOT
+module mixed(
+	input [31:0] wa, wb, wc,
+	input [7:0] na, nb, nc,
+	output [31:0] wy,
+	output [7:0] ny
+);
+	assign wy = wa + wb + wc;
+	assign ny = na + nb + nc;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+arith_tree -min-width 16
+select -assert-min 1 t:$fa
+# The narrow chain keeps both of its adders and the compressed wide chain
+# leaves one final adder behind, so three remain rather than the two that
+# compressing both chains would leave.
+select -assert-count 3 t:$add
+design -reset
+
+# The limit also applies to $macc cells, which alumacc builds from the same
+# chains and which would otherwise slip past it.
+read_verilog <<EOT
+module macc_narrow(
+	input [7:0] a, b, c, d,
+	output [7:0] y
+);
+	assign y = a * b + c * d;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+alumacc
+arith_tree -min-width 16
+select -assert-none t:$fa
+design -reset
+
+# Default (no -min-width) keeps compressing everything.
+read_verilog <<EOT
+module narrow(
+	input [7:0] a, b, c,
+	output [7:0] y
+);
+	assign y = a + b + c;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+arith_tree
+select -assert-min 1 t:$fa
+design -reset

--- a/tests/opt/opt_disjoint_add.ys
+++ b/tests/opt/opt_disjoint_add.ys
@@ -1,0 +1,156 @@
+# Tests for opt_disjoint_add
+#
+# Each group exercises a specific facet:
+#   A: the rewrite itself, including the correlated case that per-operand
+#      range analysis cannot prove.
+#   B: the soundness guards -- operands that really can overlap, an addend
+#      independent of the shift, and a signed add.
+#   C: the cost guard on the joint support width.
+#
+# The rewrite is a true equivalence (a carry-free add is an or), so each
+# positive group proves it with equiv_opt rather than a miter.
+
+# ============================================================================
+# Group A: rewrite adds whose operands never share a bit position
+# ============================================================================
+
+# A1: constant shift, addend narrower than the window. The simplest form: the
+# low 8 bits of the result come only from `lo`, the rest only from `hi`.
+log -header "A1: constant shift with a narrow addend"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [7:0] hi, input wire [7:0] lo, output wire [15:0] y);
+  assign y = (hi << 8) + lo;
+endmodule
+EOF
+prep -top top
+select -assert-count 1 t:$add
+equiv_opt -assert opt_disjoint_add
+design -load postopt
+select -assert-none t:$add
+select -assert-count 1 t:$or
+log -pop
+
+# A2: the correlated case. `sh` and the width of `fine` both track `px`, so
+# the window and the addend move together and always just meet. Taking the
+# operands separately, `fine` may reach bit 8 while `sh` may be as low as 4,
+# so only a joint sweep of the shared support proves this one.
+log -header "A2: shift amount and addend correlated through the same driver"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [15:0] coarse, input wire [3:0] f, input wire [2:0] px,
+            output wire [23:0] y);
+  wire [7:0] fine = {4'b0, f} << px;
+  wire [3:0] sh   = px + 4'd4;
+  assign y = (coarse << sh) + fine;
+endmodule
+EOF
+prep -top top
+equiv_opt -assert opt_disjoint_add
+design -load postopt
+# The $add for `sh` stays; only the wide one becomes an $or.
+select -assert-count 1 t:$or
+select -assert-count 1 t:$add
+log -pop
+
+# A3: operand order must not matter -- the shift may sit on either add port.
+log -header "A3: shifted operand on the B port"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [7:0] hi, input wire [7:0] lo, output wire [15:0] y);
+  assign y = lo + (hi << 8);
+endmodule
+EOF
+prep -top top
+equiv_opt -assert opt_disjoint_add
+design -load postopt
+select -assert-none t:$add
+select -assert-count 1 t:$or
+log -pop
+
+# ============================================================================
+# Group B: refuse when the operands can collide
+# ============================================================================
+
+# B1: A2 with the window one bit lower. `fine` tops out at bit px+3, which is
+# now exactly where the window opens, so the two collide for every px and the
+# add must survive. Only the joint sweep can tell this apart from A2.
+log -header "B1: off-by-one window -- operands overlap"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [15:0] coarse, input wire [3:0] f, input wire [2:0] px,
+            output wire [23:0] y);
+  wire [7:0] fine = {4'b0, f} << px;
+  wire [3:0] sh   = px + 4'd3;
+  assign y = (coarse << sh) + fine;
+endmodule
+EOF
+prep -top top
+opt_disjoint_add
+select -assert-none t:$or
+log -pop
+
+# B2: the addend does not depend on the shift amount at all, so nothing bounds
+# it below the window.
+log -header "B2: addend independent of the shift amount"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [15:0] coarse, input wire [7:0] fine, input wire [2:0] px,
+            output wire [23:0] y);
+  wire [3:0] sh = px + 4'd4;
+  assign y = (coarse << sh) + fine;
+endmodule
+EOF
+prep -top top
+opt_disjoint_add
+select -assert-none t:$or
+log -pop
+
+# B3: signed operands. A negative addend sets the high bits, so the carry-free
+# argument does not hold and signed adds are rejected outright.
+log -header "B3: signed add"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire signed [7:0] hi, input wire signed [7:0] lo,
+            output wire signed [15:0] y);
+  assign y = (hi <<< 8) + lo;
+endmodule
+EOF
+prep -top top
+opt_disjoint_add
+select -assert-none t:$or
+log -pop
+
+# ============================================================================
+# Group C: the sweep is exponential in the joint support, so it is capped
+# ============================================================================
+
+# C1: A2 again -- a variable window, so the proof needs the sweep. Its joint
+# support is 7 bits (px and f), which -max-support 4 puts out of reach, and
+# the candidate must be skipped rather than swept. A1's fixed window is not
+# usable here: it is proven from the operand shapes without any sweep, so no
+# support limit applies to it.
+log -header "C1: joint support above -max-support is skipped"
+log -push
+design -reset
+read_verilog -sv <<EOF
+module top (input wire [15:0] coarse, input wire [3:0] f, input wire [2:0] px,
+            output wire [23:0] y);
+  wire [7:0] fine = {4'b0, f} << px;
+  wire [3:0] sh   = px + 4'd4;
+  assign y = (coarse << sh) + fine;
+endmodule
+EOF
+prep -top top
+opt_disjoint_add -max-support 4
+select -assert-none t:$or
+# ...and is found again once the cap admits it.
+opt_disjoint_add -max-support 16
+select -assert-count 1 t:$or
+log -pop


### PR DESCRIPTION
## opt_disjoint_add

An `$add` whose operands can never hold a 1 in the same bit position carries
nowhere -- its carry-propagate network only computes a concatenation. The new
pass proves that and rewrites the cell to `$or`.

The idiom this targets is address generation: a coarse field scaled by a
run-time shift, with a fine field dropped into the hole the shift opens
underneath it.

```verilog
wire [39:0] sum = (pre << sh) + micro;   // micro always fits below bit sh
```

What makes this need a new pass is that the two fields are normally derived
from the same control register, so they are only provably disjoint when the
shift amount and the addend magnitude are reasoned about *jointly*. Independent
per-operand range analysis sees the two windows touch and gives up, which is why
`opt_expr` and friends leave it alone. The match therefore enumerates every
assignment of the joint cone support behind the shift amount and the addend with
`ConstEval`, and requires the addend to stay below the window on all of them.

The shift's *data* operand is deliberately never inspected: bit `i` of `X << s`
is zero for every `i < s` no matter what `X` is. Skipping it keeps the wide
datapath feeding the shift out of the support set, which is what makes the sweep
affordable in the first place.

A constant shift never reaches the pass as `$shl` -- it is folded to an operand
carrying literal zeros at the bottom. That form is handled structurally from the
operand shapes alone, with no sweep, and so has no limit on the addend's cone.

Soundness: signed operands are rejected, and any `ConstEval` result with
undefined bits aborts the match rather than being read as a zero. Enumeration is
bounded by `-max-support-bits`, `-max-cone-cells`, and an evaluation budget, all
of which fail closed.

## arith_tree -min-width

Callers were limiting carry-save compression to wide chains by restricting the
*selection*, which never actually worked. `arith_tree` indexes every cell of a
selected module, so a cell-level selection only chose which **modules** ran. One
wide adder anywhere in a module pulled in all of that module's narrow chains too,
and deleting that adder switched compression off for the entire module.

This adds a real per-chain limit, applied to the chain root's result width and to
`$macc` cells. Default `0` preserves existing behaviour for callers that do not
set it.

## Results

On the Silimate regression corpus, with the paired preqorsor change that runs the
pass and passes `-min-width`:

| design | LoL | area |
|---|---|---|
| `qor_tile_mul_shift` | 38.5 -> 33.75 | 187.9 |
| `mux_push_chain` | 29.5 -> 22.25 | 287.5 -> 234.3 |

`mux_push_chain` improves purely from the `-min-width` fix: its four 30-bit
chains now compress, where the old module-level gate had excluded the whole
module.

## Tests

- `tests/opt/opt_disjoint_add.ys` -- rewrite cases (variable shift with
  correlated amount, constant/zero-padded window, both operand orders), refusal
  cases (overlapping windows, addend independent of the shift, signed operands),
  and a cost guard. Every rewrite case is checked with `equiv_opt`.
- `tests/arith_tree/arith_tree_min_width.ys` -- confirms the gate is per chain,
  including a module holding one wide and one narrow chain, which is exactly the
  case the old selection got wrong.

Made with [Cursor](https://cursor.com)