### PR TITLE
muxpush: test keep across sigmap aliases, not just the elected wire

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -73,6 +73,7 @@ struct OptMuxPushWorker
   dict<SigBit, RTLIL::Cell*> driver_map;
   dict<SigBit, int> fanout_map;
   dict<SigBit, std::vector<RTLIL::Cell*>> consumer_map;
+  pool<SigBit> keep_bits;
   dict<SigBit, int> arrival_cache;
   pool<SigBit> arrival_active;
   dict<SigBit, int> depart_cache;
@@ -337,7 +338,7 @@ struct OptMuxPushWorker
     RTLIL::SigSpec arm_a, arm_b;
     if (budget > 0 && mux_drives_sig(sig, m) && design->selected(module, m) &&
         !m->get_bool_attribute(ID::keep) &&
-        !sig_has_keep(sigmap(m->getPort(ID::Y))) &&
+        !sig_has_keep(m->getPort(ID::Y)) &&
         fanout_within_limit(sigmap(m->getPort(ID::Y))) &&
         slice_arms(m, sigmap(m->getPort(ID::Y)), sig, arm_a, arm_b))
       return std::max({pushed_arrival(sigmap(arm_a), d_op, others, budget - 1),
@@ -405,6 +406,15 @@ struct OptMuxPushWorker
     driver_map.clear();
     fanout_map.clear();
     consumer_map.clear();
+    keep_bits.clear();
+
+    // Collect `keep` across every alias, not just the wire sigmap elected: the
+    // attribute may sit on any wire of a `connect` group, and testing it on the
+    // representative alone silently drops the mux a kept probe was reading.
+    for (auto wire : module->wires())
+      if (wire->get_bool_attribute(ID::keep))
+        for (auto &bit : sigmap(RTLIL::SigSpec(wire)))
+          keep_bits.insert(bit);
 
     // Build per-bit driver and fanout maps for the current module
     for (auto cell : module->cells())
@@ -449,10 +459,11 @@ struct OptMuxPushWorker
     }
   }
 
+  // Sigmaps each bit so callers may pass raw or mapped signals interchangeably.
   bool sig_has_keep(const RTLIL::SigSpec &sig)
   {
     for (auto &bit : sig) {
-      if (bit.wire != nullptr && bit.wire->get_bool_attribute(ID::keep))
+      if (bit.wire != nullptr && keep_bits.count(sigmap(bit)))
         return true;
     }
     return false;

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -498,6 +498,72 @@ design -reset
 log -pop
 
 
+log -header "Negative case: keep on an alias of the mux output blocks the push"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [7:0] a,
+  input wire [7:0] b,
+  input wire [7:0] c,
+  output wire [7:0] y
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire s = sp[3];
+  wire [7:0] m = s ? b : a;
+  (* keep *) wire [7:0] m_probe;
+  assign m_probe = m;
+  assign y = m + c;
+endmodule
+EOF
+proc
+check -assert
+
+# m_probe is `connect`-aliased to the mux output and carries keep, so the mux has
+# to stay. sigmap reports only the alias it elected for the group, so reading the
+# attribute off the mapped wire misses the one that actually carries it: the pass
+# then pushes, deletes the mux, and leaves the kept probe on an undriven net.
+equiv_opt -assert muxpush -limit 1 -types $add -timing
+design -load postopt
+select -set add_fanin t:$add %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 1 @add_fanin @mux_cells %i
+# The mux the probe reads is still there and still driven
+select -assert-count 1 t:$mux t:$ternary %u
+design -reset
+
+# Same netlist without the keep does push, so the group above is the guard
+# declining a real candidate rather than a shape the pass never matched.
+read_verilog <<EOF
+module top (
+  input wire [7:0] s_lo,
+  input wire [7:0] s_hi,
+  input wire [7:0] a,
+  input wire [7:0] b,
+  input wire [7:0] c,
+  output wire [7:0] y
+);
+  wire [7:0] sp = s_lo * s_hi;
+  wire s = sp[3];
+  wire [7:0] m = s ? b : a;
+  wire [7:0] m_probe;
+  assign m_probe = m;
+  assign y = m + c;
+endmodule
+EOF
+proc
+equiv_opt -assert muxpush -limit 1 -types $add -timing
+design -load postopt
+select -set add_fanin t:$add %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 0 @add_fanin @mux_cells %i
+
+design -reset
+log -pop
+
+
 log -header "-slack-margin rejects a negative allowance (ends the script, keep last)"
 log -push
 design -reset


### PR DESCRIPTION
## The bug

`sig_has_keep` read the attribute off the bit `SigMap` handed back:

```cpp
if (bit.wire != nullptr && bit.wire->get_bool_attribute(ID::keep))
```

A group of `connect`-aliased wires has exactly one representative, and `keep` may
sit on any member of the group. When it sits on a member that is not the elected
one, the test returns false, `muxpush` pushes, deletes the mux, and the kept net
is left with no driver at all.

This is not an exotic aliasing corner. `sigmap` routinely elects the mux cell's
generated `Y` wire over the user's named wire, so a `keep` placed directly on the
mux output was dropped too.

Reproducer, where `m_probe` carries `keep` and is aliased to the mux output:

```verilog
wire [7:0] m = s ? b : a;
(* keep *) wire [7:0] m_probe;
assign m_probe = m;
assign y = m + c;
```

On `main` this reports `Pushed muxes through 1 operator inputs.` and the kept
probe comes out undriven. With this PR it reports `0` and the mux survives.

## The fix

Collect `keep` across every alias into a bit pool while connectivity is built,
then test membership instead of the attribute. `sig_has_keep` now sigmaps its own
argument, so callers may pass raw or mapped signals interchangeably — one call
site passed `sigmap(...)` and the others did not, which is part of how the
inconsistency went unnoticed.

## Learnings

- Reading an attribute off a sigmapped bit is a category error. `SigMap` answers
  "which net is this", while attributes belong to wires. Every attribute test on
  a mapped bit has this same bug shape, so it is worth grepping for.
- The failure is silent: nothing errors, a probe simply loses its driver, and it
  surfaces far downstream of `muxpush`.
- The bug hides behind the usual test idiom. A test that puts `keep` on the wire
  the RTL names still passes whenever sigmap happens to elect that wire, so the
  negative case has to force an alias to be meaningful.

## Impact

Measured over 238 Preqorsor regression designs against `origin/main`
(`ecfcddd76`); 23 of them fire `muxpush`:

| | baseline | this PR |
|---|---|---|
| pushes | 148 | 148 |
| cells | 1940 | 1940 |
| LoL (`ltp`) | 1099 | 1099 |

No change anywhere, so nothing in the corpus was relying on a missed `keep`; the
fix only removes an incorrect push that the corpus never triggers. Controlled
runtime over 7 pre-elaborated designs (5 repeats, binaries interleaved, minimum
taken) is +0.02%, which is noise — the pool is built once per `build_connectivity`
and replaces a per-bit attribute lookup with a pool lookup.

## Testing

- New negative case in `tests/silimate/mux_push.ys`: a `keep` alias of the mux
  output blocks the push, with a positive control on the same netlist without the
  `keep` so the group proves a real candidate is being declined rather than a
  shape the matcher never saw.
- `tests/silimate/mux_push.ys` passes; the only `ERROR` line is the expected
  `-slack-margin` one, as on `main`.
