### PR TITLE
muxpush: refuse -types $mux, which cannot reach a fixpoint

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -728,7 +728,9 @@ struct OptMuxPushPass : public Pass {
     log("\n");
     log("    -types <string>\n");
     log("        comma-separated list of operator cell types to push through\n");
-    log("        (default: $add,$sub,$xor)\n");
+    log("        (default: $add,$sub,$xor). $mux is rejected: the pass emits a\n");
+    log("        $mux, so targeting it would make its own output a candidate and\n");
+    log("        never fixpoint\n");
     log("\n");
     log("    -timing\n");
     log("        only push when the push buys depth on a path that is long\n");
@@ -797,7 +799,15 @@ struct OptMuxPushPass : public Pass {
     for (auto &tok : split_tokens(types, ", \t\r\n")) {
       if (tok.empty())
         continue;
-      target_types.insert(RTLIL::escape_id(tok));
+      IdString type = RTLIL::escape_id(tok);
+      // The rewrite re-inserts a $mux at the operator's output, so targeting
+      // $mux makes the pass's own output a candidate. Each push then just
+      // rotates the two muxes -- same cell count, one more level of name -- and
+      // run() never reaches a fixpoint. Refuse rather than spin.
+      if (type == ID($mux))
+        log_cmd_error("muxpush: -types must not include $mux: it is the cell this "
+            "pass emits, so pushing a mux through a mux never fixpoints.\n");
+      target_types.insert(type);
     }
 
     int total_count = 0;

--- a/tests/silimate/mux_push_types.ys
+++ b/tests/silimate/mux_push_types.ys
@@ -1,0 +1,34 @@
+log -header "muxpush refuses -types $mux, which would never fixpoint"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s0,
+  input wire s1,
+  input wire [7:0] a,
+  input wire [7:0] b,
+  input wire [7:0] c,
+  output wire [7:0] y
+);
+  wire [7:0] m0 = s0 ? b : a;
+  assign y = s1 ? m0 : c;
+endmodule
+EOF
+proc
+check -assert
+
+# A mux feeding a mux is a shape the matcher accepts, so the refusal below has to
+# come from the type check rather than from a failure to match. With $add as the
+# target this same netlist is simply left alone.
+muxpush -limit 1 -types $add
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 2 @mux_cells
+
+# $mux is the cell the rewrite emits, so targeting it makes the pass's own output
+# a candidate: each push rotates the two muxes -- same cell count, one more level
+# of name -- and run() spins forever instead of reaching a fixpoint.
+# Keep last: an expected error ends the script.
+logger -expect error "-types must not include" 1
+muxpush -limit 1 -types $mux
+logger -check-expected
+log -pop


### PR DESCRIPTION
## The bug

`muxpush -types $mux` hangs. The rewrite re-inserts a `$mux` at the operator's
output, so naming `$mux` as a target makes the pass's own output a candidate.
Each push rotates the two muxes past each other — same cell count, one more level
of generated name — and `run()` never runs out of candidates:

```verilog
wire [7:0] m0 = s0 ? b : a;
assign y = s1 ? m0 : c;
```

```
muxpush -limit 1 -types $mux    # spins until killed
```

Every other guard in the pass is a bound on *what* to push, not on whether the
pass converges, so nothing else catches this.

## The fix

Reject the option during argument parsing, in the same style as a negative
`-slack-margin`, and say why in the help text.

`$pmux` is deliberately left alone: the cell the rewrite emits is a `$mux`, so a
`$pmux` target never feeds itself.

## Learnings

- A pass that both matches and emits cell type `T` cannot accept `T` as a target
  without a separate termination argument. That is a general property worth
  checking on any pattern pass with a configurable type list, not a `muxpush`
  quirk.
- Failing at parse time is much kinder than failing at fixpoint. The hang gives
  no output at all, so from the outside it is indistinguishable from a slow
  synthesis step on a large design, and it is only reachable by explicit user
  request — exactly the case where an error message can name the reason.

## Impact

None on any working invocation: the change only rejects an option value that
could not previously terminate. Over 238 Preqorsor regression designs against
`origin/main` (`ecfcddd76`), pushes, cells, wire bits and LoL are identical, and
controlled runtime is -0.3% (noise).

## Testing

- New `tests/silimate/mux_push_types.ys`. It first shows that a mux feeding a mux
  is a shape the matcher accepts, so the refusal comes from the type check rather
  than from a failure to match, then asserts the error. The error case is last
  because an expected error ends the script.
- `tests/silimate/mux_push.ys` passes unchanged.
