### PR TITLE
muxpush: leave combinational cycles alone

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -73,6 +73,8 @@ struct OptMuxPushWorker
   dict<SigBit, RTLIL::Cell*> driver_map;
   dict<SigBit, int> fanout_map;
   dict<SigBit, std::vector<RTLIL::Cell*>> consumer_map;
+  pool<RTLIL::Cell*> cyclic_cells;
+  bool cyclic_valid;
   dict<SigBit, int> arrival_cache;
   pool<SigBit> arrival_active;
   dict<SigBit, int> depart_cache;
@@ -89,7 +91,8 @@ struct OptMuxPushWorker
   OptMuxPushWorker(RTLIL::Design *design, RTLIL::Module *module,
       const pool<IdString> &target_types, int fanout_limit, bool timing_guard,
       int slack_margin, bool recover_folded) :
-      design(design), module(module), sigmap(module), module_depth(0),
+      design(design), module(module), sigmap(module), cyclic_valid(false),
+      module_depth(0),
       target_types(target_types), fanout_limit(fanout_limit),
       timing_guard(timing_guard), slack_margin(slack_margin),
       recover_folded(recover_folded), total_count(0)
@@ -447,6 +450,113 @@ struct OptMuxPushWorker
         fanout_map[bit]++;
       }
     }
+
+    cyclic_valid = false;
+  }
+
+  // True when `cell` sits on a combinational cycle, where a push re-creates the
+  // shape the matcher found one cell larger -- the new mux drives the operand
+  // that feeds the arm -- so run() would never run out of candidates. A cell
+  // merely downstream of a cycle is safe: nothing leads back to it, so its
+  // pushes still march toward the outputs and stop. Ask last: this is the only
+  // guard costing a graph traversal, and it is built lazily so a design that
+  // never reaches it pays nothing.
+  bool is_cyclic(RTLIL::Cell *cell)
+  {
+    if (!cyclic_valid) {
+      find_cyclic_cells();
+      cyclic_valid = true;
+    }
+    return cyclic_cells.count(cell) != 0;
+  }
+
+  // Combinational neighbours of a cell: the drivers of its inputs, or the
+  // consumers of the bits it really drives. Deduplicated, so a Kahn walk
+  // discharges each edge exactly once even where an operand repeats a bit.
+  // Registers end a combinational path, so they are neither.
+  void comb_neighbors(RTLIL::Cell *cell, bool upstream, std::vector<RTLIL::Cell*> &adj)
+  {
+    adj.clear();
+    if (upstream) {
+      for (auto &conn : cell->connections())
+        if (cell->input(conn.first))
+          for (auto &bit : sigmap(conn.second)) {
+            auto it = driver_map.find(bit);
+            if (it != driver_map.end() && it->second != nullptr &&
+                it->second != cell && !it->second->is_builtin_ff())
+              adj.push_back(it->second);
+          }
+    } else {
+      std::vector<RTLIL::SigBit> outs;
+      cell_outputs(cell, outs);
+      for (auto &bit : outs) {
+        auto it_drv = driver_map.find(bit);
+        if (it_drv == driver_map.end() || it_drv->second != cell)
+          continue;
+        auto it_cons = consumer_map.find(bit);
+        if (it_cons == consumer_map.end())
+          continue;
+        for (auto cons : it_cons->second)
+          if (cons != cell && !cons->is_builtin_ff())
+            adj.push_back(cons);
+      }
+    }
+    std::sort(adj.begin(), adj.end());
+    adj.erase(std::unique(adj.begin(), adj.end()), adj.end());
+  }
+
+  // Cells a Kahn ordering cannot place, counting `upstream` neighbours as the
+  // in-degree. Run with the edges it leaves the cycles and everything behind
+  // them; run against the edges it leaves the cycles and everything ahead.
+  void kahn_unplaceable(bool upstream, pool<RTLIL::Cell*> &out)
+  {
+    dict<RTLIL::Cell*, int> indeg;
+    std::vector<RTLIL::Cell*> ready, adj;
+
+    for (auto cell : module->cells()) {
+      if (cell->is_builtin_ff())
+        continue;
+      comb_neighbors(cell, upstream, adj);
+      indeg[cell] = GetSize(adj);
+      if (adj.empty())
+        ready.push_back(cell);
+    }
+
+    while (!ready.empty()) {
+      RTLIL::Cell *cell = ready.back();
+      ready.pop_back();
+      comb_neighbors(cell, !upstream, adj);
+      for (auto next : adj) {
+        auto it = indeg.find(next);
+        if (it != indeg.end() && --it->second == 0)
+          ready.push_back(it->first);
+      }
+    }
+
+    out.clear();
+    for (auto &it : indeg)
+      if (it.second > 0)
+        out.insert(it.first);
+  }
+
+  // A cell is on a cycle exactly when neither ordering can place it: one leaves
+  // the cycles plus what follows them, the other the cycles plus what precedes.
+  void find_cyclic_cells()
+  {
+    cyclic_cells.clear();
+
+    // The acyclic design, which is nearly all of them, stops after one walk
+    pool<RTLIL::Cell*> behind;
+    kahn_unplaceable(true, behind);
+    if (behind.empty())
+      return;
+
+    pool<RTLIL::Cell*> ahead;
+    kahn_unplaceable(false, ahead);
+    for (auto cell : behind)
+      if (ahead.count(cell))
+        cyclic_cells.insert(cell);
+    log_debug("    %d combinational cells lie on a cycle.\n", GetSize(cyclic_cells));
   }
 
   bool sig_has_keep(const RTLIL::SigSpec &sig)
@@ -584,6 +694,8 @@ struct OptMuxPushWorker
             RTLIL::SigSpec arm_b = force_bit(in_sig, sel, true);
             if (!should_push(cell, it.first, arm_a, arm_b))
               continue;
+            if (is_cyclic(cell))
+              continue;
             candidates.push_back({cell, nullptr, it.first, arm_a, arm_b, sel});
             break;
           }
@@ -604,6 +716,8 @@ struct OptMuxPushWorker
           if (!fanout_within_limit(mux_out))
             continue;
           if (!should_push(cell, it.first, arm_a, arm_b))
+            continue;
+          if (is_cyclic(cell))
             continue;
 
           // Only push one mux per operator per iteration

--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -73,7 +73,8 @@ struct OptMuxPushWorker
   dict<SigBit, RTLIL::Cell*> driver_map;
   dict<SigBit, int> fanout_map;
   dict<SigBit, std::vector<RTLIL::Cell*>> consumer_map;
-  pool<RTLIL::Cell*> cyclic_cells;
+  pool<RTLIL::Cell*> behind_cycles;
+  dict<RTLIL::Cell*, bool> cyclic_cache;
   bool cyclic_valid;
   dict<SigBit, int> arrival_cache;
   pool<SigBit> arrival_active;
@@ -457,23 +458,31 @@ struct OptMuxPushWorker
   // True when `cell` sits on a combinational cycle, where a push re-creates the
   // shape the matcher found one cell larger -- the new mux drives the operand
   // that feeds the arm -- so run() would never run out of candidates. A cell
-  // merely downstream of a cycle is safe: nothing leads back to it, so its
-  // pushes still march toward the outputs and stop. Ask last: this is the only
-  // guard costing a graph traversal, and it is built lazily so a design that
-  // never reaches it pays nothing.
+  // that merely trails a loop, or bridges two of them, is safe: nothing leads
+  // back to it, so its pushes still march toward the outputs and stop. Ask last:
+  // this is the only guard that walks the graph, and the walk is built lazily so
+  // a design that never reaches it pays nothing.
   bool is_cyclic(RTLIL::Cell *cell)
   {
     if (!cyclic_valid) {
-      find_cyclic_cells();
+      find_cells_behind_cycles();
+      cyclic_cache.clear();
       cyclic_valid = true;
     }
-    return cyclic_cells.count(cell) != 0;
+    // One Kahn walk clears the acyclic module, which is nearly every module
+    if (!behind_cycles.count(cell))
+      return false;
+    auto it = cyclic_cache.find(cell);
+    if (it == cyclic_cache.end())
+      it = cyclic_cache.insert(std::make_pair(cell, reaches_itself(cell))).first;
+    return it->second;
   }
 
   // Combinational neighbours of a cell: the drivers of its inputs, or the
-  // consumers of the bits it really drives. Deduplicated, so a Kahn walk
-  // discharges each edge exactly once even where an operand repeats a bit.
-  // Registers end a combinational path, so they are neither.
+  // consumers of the bits it really drives. Deduplicated, so a walk discharges
+  // each edge exactly once even where an operand repeats a bit. A register ends
+  // a combinational path, so it is neither; a cell that drives its own input is
+  // its own neighbour, because that self-loop is a cycle like any other.
   void comb_neighbors(RTLIL::Cell *cell, bool upstream, std::vector<RTLIL::Cell*> &adj)
   {
     adj.clear();
@@ -483,7 +492,7 @@ struct OptMuxPushWorker
           for (auto &bit : sigmap(conn.second)) {
             auto it = driver_map.find(bit);
             if (it != driver_map.end() && it->second != nullptr &&
-                it->second != cell && !it->second->is_builtin_ff())
+                !it->second->is_builtin_ff())
               adj.push_back(it->second);
           }
     } else {
@@ -497,7 +506,7 @@ struct OptMuxPushWorker
         if (it_cons == consumer_map.end())
           continue;
         for (auto cons : it_cons->second)
-          if (cons != cell && !cons->is_builtin_ff())
+          if (!cons->is_builtin_ff())
             adj.push_back(cons);
       }
     }
@@ -505,10 +514,10 @@ struct OptMuxPushWorker
     adj.erase(std::unique(adj.begin(), adj.end()), adj.end());
   }
 
-  // Cells a Kahn ordering cannot place, counting `upstream` neighbours as the
-  // in-degree. Run with the edges it leaves the cycles and everything behind
-  // them; run against the edges it leaves the cycles and everything ahead.
-  void kahn_unplaceable(bool upstream, pool<RTLIL::Cell*> &out)
+  // Cells a Kahn ordering cannot place: the cycles, plus everything they reach.
+  // A cheap over-approximation that costs one walk and, being empty for an
+  // acyclic module, answers is_cyclic outright for nearly every design.
+  void find_cells_behind_cycles()
   {
     dict<RTLIL::Cell*, int> indeg;
     std::vector<RTLIL::Cell*> ready, adj;
@@ -516,7 +525,7 @@ struct OptMuxPushWorker
     for (auto cell : module->cells()) {
       if (cell->is_builtin_ff())
         continue;
-      comb_neighbors(cell, upstream, adj);
+      comb_neighbors(cell, true, adj);
       indeg[cell] = GetSize(adj);
       if (adj.empty())
         ready.push_back(cell);
@@ -525,7 +534,7 @@ struct OptMuxPushWorker
     while (!ready.empty()) {
       RTLIL::Cell *cell = ready.back();
       ready.pop_back();
-      comb_neighbors(cell, !upstream, adj);
+      comb_neighbors(cell, false, adj);
       for (auto next : adj) {
         auto it = indeg.find(next);
         if (it != indeg.end() && --it->second == 0)
@@ -533,30 +542,36 @@ struct OptMuxPushWorker
       }
     }
 
-    out.clear();
+    behind_cycles.clear();
     for (auto &it : indeg)
       if (it.second > 0)
-        out.insert(it.first);
+        behind_cycles.insert(it.first);
+    if (!behind_cycles.empty())
+      log_debug("    %d combinational cells are in or behind a cycle.\n",
+          GetSize(behind_cycles));
   }
 
-  // A cell is on a cycle exactly when neither ordering can place it: one leaves
-  // the cycles plus what follows them, the other the cycles plus what precedes.
-  void find_cyclic_cells()
+  // Whether `cell` reaches itself, which is what puts it on a cycle rather than
+  // merely behind one. Confined to the Kahn residual, which always holds every
+  // cell of the cycle a path back to `cell` would have to travel.
+  bool reaches_itself(RTLIL::Cell *cell)
   {
-    cyclic_cells.clear();
+    pool<RTLIL::Cell*> seen;
+    std::vector<RTLIL::Cell*> queue, adj;
 
-    // The acyclic design, which is nearly all of them, stops after one walk
-    pool<RTLIL::Cell*> behind;
-    kahn_unplaceable(true, behind);
-    if (behind.empty())
-      return;
-
-    pool<RTLIL::Cell*> ahead;
-    kahn_unplaceable(false, ahead);
-    for (auto cell : behind)
-      if (ahead.count(cell))
-        cyclic_cells.insert(cell);
-    log_debug("    %d combinational cells lie on a cycle.\n", GetSize(cyclic_cells));
+    comb_neighbors(cell, false, queue);
+    while (!queue.empty()) {
+      RTLIL::Cell *next = queue.back();
+      queue.pop_back();
+      if (next == cell)
+        return true;
+      if (!behind_cycles.count(next) || seen.count(next))
+        continue;
+      seen.insert(next);
+      comb_neighbors(next, false, adj);
+      queue.insert(queue.end(), adj.begin(), adj.end());
+    }
+    return false;
   }
 
   bool sig_has_keep(const RTLIL::SigSpec &sig)

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -566,6 +566,60 @@ select -assert-count 1 @add_fanin @mux_cells %i
 select -assert-count 3 t:$add
 
 design -reset
+
+# An operator that drives one of its own inputs is a one-cell cycle, and pushing
+# it hands the copies a mux that feeds them straight back.
+read_verilog <<EOF
+module top (
+  input wire s,
+  input wire [7:0] a,
+  input wire [7:0] b,
+  output wire [7:0] y
+);
+  wire [7:0] m = s ? b : a;
+  wire [7:0] t;
+  assign t = m + t;
+  assign y = t;
+endmodule
+EOF
+proc
+muxpush -limit 1 -types $add
+select -assert-count 1 t:$add
+
+design -reset
+
+# A cell bridging two loops is on neither, so it still pushes: reaching a cycle
+# and being reached by one is not the same as lying on one.
+read_verilog <<EOF
+module top (
+  input wire s1,
+  input wire [7:0] a1,
+  input wire [7:0] c1,
+  input wire s2,
+  input wire [7:0] c2,
+  input wire sb,
+  input wire [7:0] bb,
+  input wire [7:0] cb,
+  output wire [7:0] y
+);
+  wire [7:0] m1, t1;
+  assign m1 = s1 ? t1 : a1;
+  assign t1 = m1 + c1;
+  wire [7:0] mb = sb ? bb : t1;
+  wire [7:0] tb;
+  assign tb = mb + cb;
+  wire [7:0] m2, t2;
+  assign m2 = s2 ? t2 : tb;
+  assign t2 = m2 + c2;
+  assign y = t2;
+endmodule
+EOF
+proc
+muxpush -limit 1 -types $add
+# The bridge adder split in two; the adder on each loop stayed put
+select -assert-count 4 t:$add
+
+design -reset
 log -pop
 
 

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -498,6 +498,77 @@ design -reset
 log -pop
 
 
+log -header "Negative case: a combinational cycle through an arm is left alone"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s,
+  input wire [7:0] a,
+  input wire [7:0] c,
+  input wire [7:0] q,
+  output wire [7:0] y
+);
+  wire [7:0] m;
+  wire [7:0] t;
+  assign m = s ? t : a;
+  assign t = m + c;
+  assign y = q;
+endmodule
+EOF
+proc
+
+# t feeds the mux arm and the mux drives t, both at fanout 1. Pushing here just
+# re-creates that shape one adder larger, so the pass keeps finding a candidate
+# and never terminates -- with or without -timing. `check` is not asserted: the
+# combinational loop is the point of the case.
+muxpush -limit 1 -types $add
+select -assert-count 1 t:$add
+select -set add_fanin t:$add %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 1 @add_fanin @mux_cells %i
+
+muxpush -limit 1 -types $add -timing
+select -assert-count 1 t:$add
+
+design -reset
+
+# The guard is scoped to the cycle itself, not to everything the cycle reaches:
+# the same mux/adder shape strictly downstream of a loop has nothing leading back
+# to it, so its pushes still march toward the outputs and stop. Left in place,
+# this also shows the case above is a cycle being declined rather than every mux
+# that feeds an adder at fanout 1.
+read_verilog <<EOF
+module top (
+  input wire sx,
+  input wire [7:0] ax,
+  input wire [7:0] cx,
+  input wire s,
+  input wire [7:0] b,
+  input wire [7:0] c,
+  output wire [7:0] y
+);
+  wire [7:0] mx;
+  wire [7:0] tx;
+  assign mx = sx ? tx : ax;
+  assign tx = mx + cx;
+  wire [7:0] m = s ? b : tx;
+  assign y = m + c;
+endmodule
+EOF
+proc
+muxpush -limit 1 -types $add
+# The downstream adder pushed, so only its speculated copies read the mux
+select -set add_fanin t:$add %ci*
+select -set mux_cells t:$mux t:$ternary
+select -assert-count 1 @add_fanin @mux_cells %i
+# ...and the adder on the cycle was left alone
+select -assert-count 3 t:$add
+
+design -reset
+log -pop
+
+
 log -header "-slack-margin rejects a negative allowance (ends the script, keep last)"
 log -push
 design -reset


### PR DESCRIPTION
## The bug

A push inside a combinational cycle re-creates the shape it just matched, one
cell larger: the new mux drives the operand that feeds the arm. `run()` therefore
always finds another candidate and never terminates.

```verilog
wire [7:0] m, t;
assign m = s ? t : a;   // mux arm is fed by the adder
assign t = m + c;       // adder is fed by the mux
```

```
muxpush -limit 1 -types $add            # spins until killed
muxpush -limit 1 -types $add -timing    # likewise
```

Wider cycles do stop today, but only because the fanout cap eventually rejects
the candidate. That is luck, not a guard: the pass has no notion of a cycle at
all, and `arrival` already carries an `arrival_active` recursion guard precisely
because cyclic netlists reach it.

## The fix

Refuse a candidate whose operator lies on a cycle, which is exactly the operators
that can reach themselves.

Answering that per candidate would mean walking the fanout cone every time, so a
Kahn walk runs first as a cheap filter: what it cannot place is the cycles plus
everything they reach, and on a well-formed netlist that set is empty, which
clears the whole module in one pass. Only a candidate inside the residual is
asked the exact question, and its search stays inside the residual, which always
holds every cell of the cycle a path home would have to travel.

Testing the operator alone is enough: the operator consumes the select, so a mux
on a cycle leaves the operator on it too.

Scoping the guard this tightly is the point. A cell that merely trails a loop, or
bridges two of them, has nothing leading back to it, so its pushes still march
toward the outputs and stop; refusing the whole implicated cone would silently
forfeit every push behind any loop in the module.

## Learnings

- Every cheap approximation of "on a cycle" that I tried was wrong in a way that
  only a purpose-built netlist exposes. "Whatever Kahn could not place" is
  `cycle ∪ downstream`, which forfeits real pushes. Intersecting a forward and a
  reverse Kahn residual looks like it isolates the cycles, but it also keeps
  every cell on an acyclic path *between* two of them. Excluding self-edges to
  keep the walk tidy hides a one-cell cycle from both directions. The reachability
  question is the only formulation that is simply correct, and the Kahn walk earns
  its place as a filter rather than as the answer.
- Adversarial cases need their own control. One case that looked like
  over-blocking turned out to be `main` pushing *inside* the loop and getting
  away with it; the push the case was named for had been declined by `-timing`
  all along. Reading the `log_debug` line for what the guard actually marked,
  rather than the push count, is what separated the two.
- Guard ordering is a performance decision. This is the only guard in the pass
  that walks the graph, so it is asked last, after every cheaper check has had a
  chance to reject the candidate. Hoisting it to the top of the operator loop —
  the obvious placement — costs 11.7% of `muxpush` runtime on a 120k-cell netlist
  for no behavioural gain.

## Impact

Measured over 238 Preqorsor regression designs against `origin/main`
(`ecfcddd76`); 23 of them fire `muxpush`:

| | baseline | this PR |
|---|---|---|
| pushes | 148 | 148 |
| cells | 1940 | 1940 |
| LoL (`ltp`) | 1099 | 1099 |

No QoR change: none of these designs has a combinational loop, which is the
expected shape of the result — the guard is meant to be unreachable on
well-formed RTL.

Controlled runtime over 7 pre-elaborated designs (5 repeats, binaries
interleaved, minimum taken) is +1.8% in total, worst case +3.8%, on a machine
that was otherwise loaded. The cost is one Kahn walk per `run()` iteration that
reaches a candidate, and nothing at all for an iteration that does not.

## Testing

New group in `tests/silimate/mux_push.ys`, covering both directions of the guard:

- the arm cycle above is left alone, with and without `-timing`;
- the same mux/adder shape strictly downstream of a live loop still pushes, and
  the adder on the loop stays put;
- an operator driving its own input is refused;
- a cell bridging two loops still pushes.

`tests/silimate/mux_push.ys` passes; the only `ERROR` line is the expected
`-slack-margin` one, as on `main`.
