### PR TITLE
l2j_frontend: declare Liberty pg_pins as ports

### DIFF
--- a/passes/silimate/l2j_frontend.cc
+++ b/passes/silimate/l2j_frontend.cc
@@ -326,6 +326,10 @@ struct L2JFrontend : public Frontend {
 				current_module->set_src_attribute(cell["src"].get<std::string>());
 			}
 
+			// Power/ground pins, collected while walking the signal pins and declared after them
+			// (see below). Pairs of pin name and pg_type.
+			std::vector<std::pair<std::string, std::string>> pg_pins;
+
 			for_each_group(cell, [&](const json &g) {
 				if (g.count("pin")) {
 					const json pin = g["pin"].get<json::object_t>();
@@ -333,6 +337,12 @@ struct L2JFrontend : public Frontend {
 					const auto pin_names = pin.value<json::array_t>("names", {});
 					for (auto &pin_name: pin_names) {
 						add_port(current_module, pin_name.get<std::string>(), 1, direction);
+					}
+				} else if (g.count("pg_pin")) {
+					const json pg_pin = g["pg_pin"].get<json::object_t>();
+					const auto pg_type = pg_pin.value<std::string>("pg_type", "");
+					for (auto &pin_name: pg_pin.value<json::array_t>("names", {})) {
+						pg_pins.emplace_back(pin_name.get<std::string>(), pg_type);
 					}
 				} else if (g.count("bus")) {
 					const json bus = g["bus"].get<json::object_t>();
@@ -370,6 +380,19 @@ struct L2JFrontend : public Frontend {
 					}
 				}
 			});
+
+			// Vendor Verilog views declare power/ground pins as ports, so RTL routinely connects
+			// them: declare them here too, or those instantiations cannot bind. OpenSTA likewise
+			// turns pg_pins into ports. Appending them keeps the signal pin positions unchanged
+			// for positional instantiations.
+			for (auto &[pg_name, pg_type]: pg_pins) {
+				// Input rather than inout: a cell never drives its own supply, and RTLIL has no
+				// power/ground direction, so an inout would make the cell look like a driver.
+				RTLIL::Wire *port = add_port(current_module, pg_name, 1, "input");
+				// Tag the port so consumers can tell supplies apart from signal pins
+				if (port && !pg_type.empty())
+					port->set_string_attribute(ID(pg_type), pg_type);
+			}
 		});
 		} catch (json::parse_error &e) {
 			log_error("Failed to parse liberty json file: %s\n", e.what());

--- a/tests/various/l2j_pg_pin_ports.ys
+++ b/tests/various/l2j_pg_pin_ports.ys
@@ -1,0 +1,37 @@
+# Regression test: Liberty `pg_pin` groups must become ports on the blackbox module.
+#
+# Vendor Verilog views of a macro declare its power/ground pins as ports, so RTL that
+# instantiates the macro connects them. When the Liberty file is the only view of the
+# cell, those connections bind against the blackbox this frontend creates, so dropping
+# pg_pin groups makes the instantiation unresolvable (Verific VERI-1010, or
+# `hierarchy -check` "does not have a port named ..."). OpenSTA's Liberty reader also
+# turns each pg_pin into a port, so declaring them keeps the two views consistent.
+#
+# The pins are inputs, not inouts: a cell never drives its own supply, and RTLIL has no
+# power/ground direction, so an inout would make the cell look like a driver of the net.
+#
+# The pg_pin groups below deliberately precede the signal pins, because the ports must
+# still be appended after them (port_id 3 and 4, not 1 and 2): positional instantiations
+# of the cell keep binding to the same signal pins as before supplies were declared.
+
+read_liberty2json << EOT
+{"library": {"leakage_power_unit": "1nW", "groups": [
+  {"cell": {"names": ["MACRO"], "area": 100.0, "cell_leakage_power": 1.0, "groups": [
+    {"pg_pin": {"names": ["VDD"], "pg_type": "primary_power", "voltage_name": "VDD"}},
+    {"pg_pin": {"names": ["VSS"], "pg_type": "primary_ground", "voltage_name": "VSS"}},
+    {"pin": {"names": ["A"], "direction": "input"}},
+    {"pin": {"names": ["Y"], "direction": "output"}}
+  ]}}
+]}}
+EOT
+
+# Signal pins keep ports 1 and 2, supplies are appended as inputs carrying their pg_type
+logger -expect log "wire input 1 \\A" 1
+logger -expect log "wire output 2 \\Y" 1
+logger -expect log "attribute \\pg_type \"primary_power\"" 1
+logger -expect log "wire input 3 \\VDD" 1
+logger -expect log "attribute \\pg_type \"primary_ground\"" 1
+logger -expect log "wire input 4 \\VSS" 1
+logger -expect-no-warnings
+dump =MACRO
+logger -check-expected


### PR DESCRIPTION
## Summary

`read_liberty2json` silently dropped every `pg_pin` group, so a Liberty-derived
blackbox had no supply ports. A vendor Verilog view of the same macro declares
its supplies as ports, so RTL that instantiates the macro connects them by name,
and those connections had nothing to bind against:

```
[VERI-1010] psm_CORE_PSM_IP_OSC_N2.v:304: cannot find port 'VDD1' on instantiated module 'mapsmro_tsmc2n17m'
[VERI-1310] preqorsor/data/blackboxes.v:826832: 'mapsmro_tsmc2n17m' is declared here
```

Without Verific the same design fails `hierarchy -check` with "does not have a
port named". OpenSTA's Liberty reader already models each `pg_pin` as a port, so
declaring them here keeps the RTLIL and timing views consistent rather than
divergent.

Three details worth reviewing:

- The supplies are **appended after** all signal pins, so positional
  instantiations keep binding to the same pins as before. The test deliberately
  puts the `pg_pin` groups first in the Liberty JSON to lock this in.
- They are declared **`input`, not `inout`**: a cell never drives its own
  supply, and RTLIL has no power/ground direction, so an `inout` would make the
  cell look like a driver of the net.
- Each port carries its `pg_type` attribute, which is how consumers tell
  supplies apart from signal pins (Preqorsor's SAIF writer uses it to skip
  ports that STA reports no switching activity for).

## Test plan

- [x] `tests/various/l2j_pg_pin_ports.ys` passes with this change and fails
      without it (the supplies land at port ids 3 and 4, after the signal pins,
      each with its `pg_type`).
- [x] Verified end to end in Preqorsor: the generated `blackboxes.v` now
      declares `input VDD;` / `input VSS;` for a gf180 SRAM macro, and the
      `pg_type` attribute survives the Liberty-to-Verilog cache round trip.
- [ ] A `pg_pin` group with no `pg_type` (only synthetic test libraries do this,
      the attribute is required by the Liberty spec) gets a port with no tag,
      since Yosys erases a string attribute set to the empty string.

Made with [Cursor](https://cursor.com)