### PR TITLE
muxpush: lift a late default out of a mux priority chain

### DIFF
--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -579,6 +579,11 @@ struct OptMuxPushWorker
       return nullptr;
     if (!fanout_is_one(sig) || sig_has_keep(sig))
       return nullptr;
+    // Absorbing a link deletes it, so one the caller kept or left out of the
+    // selection has to end the walk instead. Checking only the arm signal misses
+    // both: keep on the cell says nothing about the wire it drives.
+    if (!design->selected(module, drv) || drv->get_bool_attribute(ID::keep))
+      return nullptr;
     // Partial coverage would leave the inner mux's other bits undriven once the
     // chain is rebuilt, so demand the arm be the whole output.
     return sigmap(drv->getPort(ID::Y)) == sig ? drv : nullptr;
@@ -726,6 +731,8 @@ struct OptMuxPushWorker
     pool<RTLIL::Cell*> cells_to_remove;
     for (auto cell : module->selected_cells()) {
       if (!cell->type.in(ID($mux), ID($pmux)) || cells_to_remove.count(cell))
+        continue;
+      if (cell->get_bool_attribute(ID::keep))
         continue;
       RTLIL::SigSpec out = sigmap(cell->getPort(ID::Y));
       if (sig_has_keep(out) || GetSize(out) == 0)

--- a/passes/silimate/mux_push.cc
+++ b/passes/silimate/mux_push.cc
@@ -85,15 +85,18 @@ struct OptMuxPushWorker
   bool timing_guard;
   int slack_margin;
   bool recover_folded;
+  int hoist_gain;
   int total_count;
+  int hoist_count;
+  int chains_seen = 0, chains_cheap = 0, chains_slack = 0;
 
   OptMuxPushWorker(RTLIL::Design *design, RTLIL::Module *module,
       const pool<IdString> &target_types, int fanout_limit, bool timing_guard,
-      int slack_margin, bool recover_folded) :
+      int slack_margin, bool recover_folded, int hoist_gain) :
       design(design), module(module), sigmap(module), module_depth(0),
       target_types(target_types), fanout_limit(fanout_limit),
       timing_guard(timing_guard), slack_margin(slack_margin),
-      recover_folded(recover_folded), total_count(0)
+      recover_folded(recover_folded), hoist_gain(hoist_gain), total_count(0), hoist_count(0)
   {
   }
 
@@ -546,6 +549,224 @@ struct OptMuxPushWorker
     return true;
   }
 
+  // One link of a mux priority chain: the arms that leave the chain here, and
+  // the select that takes them. A $pmux link carries S_WIDTH arms at once.
+  struct ChainStep {
+    RTLIL::Cell *cell;
+    RTLIL::SigSpec leaves;
+    RTLIL::SigSpec sel;
+    bool leaf_on_b;
+    bool is_pmux;
+    int levels;
+  };
+
+  // Is `sig` exactly the output of a private mux, so the chain can absorb it?
+  RTLIL::Cell *private_link(const RTLIL::SigSpec &sig)
+  {
+    RTLIL::Cell *drv = nullptr;
+    for (auto &bit : sig) {
+      if (bit.wire == nullptr)
+        return nullptr;
+      auto it = driver_map.find(bit);
+      if (it == driver_map.end() || it->second == nullptr)
+        return nullptr;
+      if (drv == nullptr)
+        drv = it->second;
+      else if (drv != it->second)
+        return nullptr;
+    }
+    if (drv == nullptr || !drv->type.in(ID($mux), ID($pmux)))
+      return nullptr;
+    if (!fanout_is_one(sig) || sig_has_keep(sig))
+      return nullptr;
+    // Partial coverage would leave the inner mux's other bits undriven once the
+    // chain is rebuilt, so demand the arm be the whole output.
+    return sigmap(drv->getPort(ID::Y)) == sig ? drv : nullptr;
+  }
+
+  // Walk down the default arms of a priority chain rooted at `root`. A bottom
+  // $mux contributes both arms: the later one is kept as the default, since that
+  // is the arm the rewrite lifts out.
+  bool collect_chain(RTLIL::Cell *root, std::vector<ChainStep> &steps, RTLIL::SigSpec &def)
+  {
+    RTLIL::Cell *cur = root;
+    int total = 0;
+    while (true) {
+      RTLIL::SigSpec a = sigmap(cur->getPort(ID::A));
+      RTLIL::SigSpec b = sigmap(cur->getPort(ID::B));
+      RTLIL::SigSpec s = sigmap(cur->getPort(ID::S));
+      bool pm = cur->type == ID($pmux);
+      if (pm ? GetSize(b) != GetSize(a) * GetSize(s)
+             : (GetSize(s) != 1 || GetSize(a) != GetSize(b)))
+        return false;
+      // A $pmux lowers to a priority chain, so its default pays per select bit.
+      int lv = pm ? log2p1_int(GetSize(s)) : 1;
+      total += lv;
+
+      if (RTLIL::Cell *next_a = private_link(a)) {
+        steps.push_back({cur, b, s, true, pm, lv});
+        cur = next_a;
+        continue;
+      }
+      // Only a $mux can be entered from B: a $pmux's B holds its arms.
+      if (!pm) {
+        if (RTLIL::Cell *next_b = private_link(b)) {
+          steps.push_back({cur, a, s, false, false, lv});
+          cur = next_b;
+          continue;
+        }
+      }
+
+      if (pm) {
+        steps.push_back({cur, b, s, true, true, lv});
+        def = a;
+      } else {
+        bool def_is_a = arrival(a) >= arrival(b);
+        steps.push_back({cur, def_is_a ? b : a, s, def_is_a, false, lv});
+        def = def_is_a ? a : b;
+      }
+      return total >= 2;
+    }
+  }
+
+  // The rest chain seeds from the bottom link. A bottom $mux collapses into its
+  // own leaf, a bottom $pmux still has to select among its arms.
+  RTLIL::SigSpec chain_seed(const std::vector<ChainStep> &steps, int width, int &start)
+  {
+    const ChainStep &bot = steps.back();
+    start = GetSize(steps) - (bot.is_pmux ? 1 : 2);
+    return bot.is_pmux ? bot.leaves.extract(0, width) : bot.leaves;
+  }
+
+  // Lift the chain's default arm to the output under the accumulated not-taken
+  // condition. The early arms rebuild beside it, so the late arm ends up one mux
+  // from the output instead of paying for every link above it.
+  void hoist_chain(RTLIL::Cell *root, std::vector<ChainStep> &steps, const RTLIL::SigSpec &def,
+      pool<RTLIL::Cell*> &cells_to_remove)
+  {
+    const std::string src = root->get_src_attribute();
+    int width = GetSize(def), start = 0;
+    RTLIL::SigSpec cur = chain_seed(steps, width, start);
+
+    for (int j = start; j >= 0; j--) {
+      const ChainStep &st = steps[j];
+      RTLIL::Wire *w = module->addWire(NEW_ID_SUFFIX("muxhoist_rest"), width);
+      if (st.is_pmux)
+        module->addPmux(NEW_ID_SUFFIX("muxhoist_pmux"), cur, st.leaves, st.sel, w, src);
+      else
+        module->addMux(NEW_ID_SUFFIX("muxhoist_mux"), st.leaf_on_b ? cur : st.leaves,
+            st.leaf_on_b ? st.leaves : cur, st.sel, w, src);
+      cur = w;
+    }
+
+    // Guard: every arm above the default was passed over.
+    RTLIL::SigSpec not_taken;
+    for (auto &st : steps) {
+      if (!st.is_pmux && !st.leaf_on_b) {
+        not_taken.append(st.sel);
+        continue;
+      }
+      RTLIL::Wire *inv = module->addWire(NEW_ID_SUFFIX("muxhoist_nsel"), GetSize(st.sel));
+      module->addNot(NEW_ID_SUFFIX("muxhoist_not"), st.sel, inv, false, src);
+      not_taken.append(inv);
+    }
+    RTLIL::Wire *guard = module->addWire(NEW_ID_SUFFIX("muxhoist_guard"));
+    module->addReduceAnd(NEW_ID_SUFFIX("muxhoist_all"), not_taken, guard, false, src);
+
+    RTLIL::SigSpec out = sigmap(root->getPort(ID::Y));
+    RTLIL::Wire *rewritten = module->addWire(NEW_ID_SUFFIX("muxhoist_out"), GetSize(out));
+    module->addMux(NEW_ID_SUFFIX("muxhoist_late"), cur, def, guard, rewritten, src);
+
+    for (auto &st : steps)
+      cells_to_remove.insert(st.cell);
+    module->connect(out, rewritten);
+  }
+
+  // Estimated output arrival before and after the hoist, under the same unit
+  // model as the push heuristic. Rejecting on this keeps the rewrite from firing
+  // where the default is not actually the chain's late arm.
+  bool hoist_pays(const std::vector<ChainStep> &steps, const RTLIL::SigSpec &def)
+  {
+    int n = GetSize(steps), start = 0, sel_bits = 0, sels = 0, cum = 0;
+    std::vector<int> to_out(n);
+    for (int j = 0; j < n; j++) {
+      cum += steps[j].levels;
+      to_out[j] = cum;
+      sel_bits += GetSize(steps[j].sel);
+      sels = std::max(sels, arrival(steps[j].sel));
+    }
+
+    int before = arrival(def) + cum;
+    for (int j = 0; j < n; j++)
+      before = std::max(before,
+          std::max(arrival(steps[j].leaves), arrival(steps[j].sel)) + to_out[j]);
+
+    RTLIL::SigSpec seed = chain_seed(steps, GetSize(def), start);
+    int rest = arrival(seed) + (start < 0 ? 0 : to_out[start]);
+    for (int j = 0; j <= start; j++)
+      rest = std::max(rest,
+          std::max(arrival(steps[j].leaves), arrival(steps[j].sel)) + to_out[j]);
+
+    int after = std::max({arrival(def) + 1, rest + 1, sels + log2p1_int(sel_bits) + 1});
+    // Downstream remapping reshapes shallow wins away, so only take chains where
+    // the model predicts a margin worth the extra guard.
+    return after + hoist_gain <= before;
+  }
+
+  void run_hoist()
+  {
+    build_connectivity();
+    arrival_cache.clear();
+    arrival_active.clear();
+    depart_cache.clear();
+    depart_active.clear();
+    if (timing_guard)
+      compute_module_depth();
+
+    pool<RTLIL::Cell*> cells_to_remove;
+    for (auto cell : module->selected_cells()) {
+      if (!cell->type.in(ID($mux), ID($pmux)) || cells_to_remove.count(cell))
+        continue;
+      RTLIL::SigSpec out = sigmap(cell->getPort(ID::Y));
+      if (sig_has_keep(out) || GetSize(out) == 0)
+        continue;
+      // Starting mid-chain would rebuild a chain the parent still owns.
+      if (fanout_is_one(out)) {
+        auto it = consumer_map.find(out[0]);
+        if (it != consumer_map.end() && GetSize(it->second) == 1 &&
+            it->second[0]->type.in(ID($mux), ID($pmux)))
+          continue;
+      }
+
+      std::vector<ChainStep> steps;
+      RTLIL::SigSpec def;
+      if (!collect_chain(cell, steps, def))
+        continue;
+      chains_seen++;
+      bool overlaps = false;
+      for (auto &st : steps)
+        overlaps |= cells_to_remove.count(st.cell) > 0;
+      if (overlaps)
+        continue;
+      if (!hoist_pays(steps, def)) {
+        chains_cheap++;
+        continue;
+      }
+      if (timing_guard && path_depth(out) < module_depth - slack_margin) {
+        chains_slack++;
+        continue;
+      }
+
+      hoist_chain(cell, steps, def, cells_to_remove);
+      hoist_count++;
+    }
+
+    log_debug("  hoist: %d chain(s), %d unprofitable, %d off-critical.\n",
+        chains_seen, chains_cheap, chains_slack);
+    for (auto cell : cells_to_remove)
+      module->remove(cell);
+  }
+
   void run()
   {
     while (true)
@@ -763,6 +984,18 @@ struct OptMuxPushPass : public Pass {
     log("        amounts, or on comparators after the pattern matchers have run,\n");
     log("        measured worse than leaving the operand alone\n");
     log("\n");
+    log("    -hoist-late\n");
+    log("        lift the late arm out of a mux priority chain. A datapath\n");
+    log("        feeding the default of a chain of control muxes pays one level\n");
+    log("        per control mux, but the chain is a priority select, so that arm\n");
+    log("        can be taken under the accumulated not-taken condition and the\n");
+    log("        early arms rebuilt beside it. Only fires when a unit-level\n");
+    log("        estimate says the default really is the chain's late arm\n");
+    log("\n");
+    log("    -hoist-gain <int>\n");
+    log("        levels the hoist must buy before it fires (default: 2). Shallow\n");
+    log("        wins do not survive downstream remapping\n");
+    log("\n");
   }
 
   void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -771,6 +1004,8 @@ struct OptMuxPushPass : public Pass {
     bool timing_guard = false;
     int slack_margin = 0;
     bool recover_folded = false;
+    bool hoist_late = false;
+    int hoist_gain = 2;
     std::string types = "$add,$sub,$xor";
 
     log_header(design, "Executing MUXPUSH pass (push muxes through light ops).\n");
@@ -791,6 +1026,16 @@ struct OptMuxPushPass : public Pass {
       }
       if (args[argidx] == "-folded-select") {
         recover_folded = true;
+        continue;
+      }
+      if (args[argidx] == "-hoist-late") {
+        hoist_late = true;
+        continue;
+      }
+      if (args[argidx] == "-hoist-gain" && argidx+1 < args.size()) {
+        hoist_gain = atoi(args[++argidx].c_str());
+        if (hoist_gain < 1)
+          log_cmd_error("muxpush: -hoist-gain must be at least 1.\n");
         continue;
       }
       if ((args[argidx] == "-slack-margin" || args[argidx] == "-slack_margin")
@@ -821,17 +1066,22 @@ struct OptMuxPushPass : public Pass {
       target_types.insert(type);
     }
 
-    int total_count = 0;
+    int total_count = 0, hoist_count = 0;
     for (auto module : design->selected_modules()) {
       if (module->get_bool_attribute(ID::blackbox))
         continue;
       OptMuxPushWorker worker(design, module, target_types, fanout_limit, timing_guard,
-          slack_margin, recover_folded);
+          slack_margin, recover_folded, hoist_gain);
+      if (hoist_late)
+        worker.run_hoist();
       worker.run();
       total_count += worker.total_count;
+      hoist_count += worker.hoist_count;
     }
 
     log("  Pushed muxes through %d operator inputs.\n", total_count);
+    if (hoist_late)
+      log("  Hoisted the late arm out of %d mux priority chain(s).\n", hoist_count);
   }
 } OptMuxPushPass;
 

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -564,6 +564,145 @@ design -reset
 log -pop
 
 
+log -header "-hoist-late: a late default is lifted out of a mux priority chain"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s0,
+  input wire s1,
+  input wire s2,
+  input wire [7:0] e0,
+  input wire [7:0] e1,
+  input wire [7:0] e2,
+  input wire [7:0] d_lo,
+  input wire [7:0] d_hi,
+  output wire [7:0] y
+);
+  wire [7:0] late = d_lo * d_hi;
+  assign y = s0 ? e0 : s1 ? e1 : s2 ? e2 : late;
+endmodule
+EOF
+proc
+check -assert
+
+# The multiply is the only late arm and it sits at the bottom of the chain, so it
+# pays for all three control muxes. The chain is a priority select, so it can be
+# taken under "no select fired" instead and land one mux from the output while
+# the early arms rebuild beside it: 11 levels before, 9 after.
+equiv_opt -assert muxpush -hoist-late
+design -load postopt
+# The accumulated not-taken condition is the rewrite's signature.
+select -assert-count 1 t:$reduce_and
+
+design -reset
+log -pop
+
+
+log -header "-hoist-late: refuses a chain whose default is not the late arm"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s0,
+  input wire s1,
+  input wire s2,
+  input wire [7:0] e0,
+  input wire [7:0] e1,
+  input wire [7:0] e2,
+  input wire [7:0] e3,
+  output wire [7:0] y
+);
+  assign y = s0 ? e0 : s1 ? e1 : s2 ? e2 : e3;
+endmodule
+EOF
+proc
+check -assert
+
+# Same chain with every arm a module input. The default still crosses three muxes,
+# but so does the topmost select, so lifting it cannot shorten the longest path --
+# it only adds the guard. Firing on chain shape alone would take this one.
+equiv_opt -assert muxpush -hoist-late
+design -load postopt
+select -assert-count 0 t:$reduce_and
+
+design -reset
+log -pop
+
+
+log -header "-hoist-late: a pmux default pays per select bit"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [3:0] sel,
+  input wire [7:0] e0,
+  input wire [7:0] e1,
+  input wire [7:0] e2,
+  input wire [7:0] e3,
+  input wire [7:0] d_lo,
+  input wire [7:0] d_hi,
+  output reg [7:0] y
+);
+  wire [7:0] late = d_lo * d_hi;
+  always @* begin
+    case (1'b1)
+      sel[0]:  y = e0;
+      sel[1]:  y = e1;
+      sel[2]:  y = e2;
+      sel[3]:  y = e3;
+      default: y = late;
+    endcase
+  end
+endmodule
+EOF
+proc
+check -assert
+
+# A $pmux hides the chain in one cell, but it lowers back to a priority chain, so
+# its default is charged log2 of the select width rather than a single level.
+# Pricing it as one level reads this as break-even and leaves the multiply behind
+# the whole case statement.
+equiv_opt -assert muxpush -hoist-late
+design -load postopt
+select -assert-count 1 t:$reduce_and
+
+design -reset
+log -pop
+
+
+log -header "-hoist-gain: a higher bar declines a chain the default takes"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s0,
+  input wire s1,
+  input wire s2,
+  input wire [7:0] e0,
+  input wire [7:0] e1,
+  input wire [7:0] e2,
+  input wire [7:0] d_lo,
+  input wire [7:0] d_hi,
+  output wire [7:0] y
+);
+  wire [7:0] late = d_lo * d_hi;
+  assign y = s0 ? e0 : s1 ? e1 : s2 ? e2 : late;
+endmodule
+EOF
+proc
+check -assert
+
+# The first group's netlist, which buys exactly two levels. Asking for three
+# declines it, so the threshold is what gates the rewrite rather than the match.
+equiv_opt -assert muxpush -hoist-late -hoist-gain 3
+design -load postopt
+select -assert-count 0 t:$reduce_and
+
+design -reset
+log -pop
+
+
 log -header "-slack-margin rejects a negative allowance (ends the script, keep last)"
 log -push
 design -reset

--- a/tests/silimate/mux_push.ys
+++ b/tests/silimate/mux_push.ys
@@ -646,6 +646,7 @@ module top (
 );
   wire [7:0] late = d_lo * d_hi;
   always @* begin
+    (* parallel_case *)
     case (1'b1)
       sel[0]:  y = e0;
       sel[1]:  y = e1;
@@ -658,6 +659,9 @@ endmodule
 EOF
 proc
 check -assert
+# Without parallel_case proc emits a plain mux chain, and this group would then
+# retest the shape above instead of the one it is named for.
+select -assert-count 1 t:$pmux
 
 # A $pmux hides the chain in one cell, but it lowers back to a priority chain, so
 # its default is charged log2 of the select width rather than a single level.
@@ -666,6 +670,107 @@ check -assert
 equiv_opt -assert muxpush -hoist-late
 design -load postopt
 select -assert-count 1 t:$reduce_and
+
+design -reset
+log -pop
+
+
+log -header "-hoist-late: keep on a chain link stops the walk"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s0,
+  input wire s1,
+  input wire [1:0] sel,
+  input wire [7:0] e0,
+  input wire [7:0] e1,
+  input wire [7:0] e2,
+  input wire [7:0] e3,
+  input wire [7:0] d_lo,
+  input wire [7:0] d_hi,
+  output wire [7:0] y
+);
+  wire [7:0] late = d_lo * d_hi;
+  reg [7:0] inner;
+  always @* begin
+    (* parallel_case *)
+    case (1'b1)
+      sel[0]:  inner = e2;
+      sel[1]:  inner = e3;
+      default: inner = late;
+    endcase
+  end
+  assign y = s0 ? e0 : (s1 ? e1 : inner);
+endmodule
+EOF
+proc
+check -assert
+select -assert-count 1 t:$pmux
+design -save chain_over_pmux
+
+# The rewrite deletes every link it absorbs, so a kept link has to end the walk.
+# keep sits on the cell and says nothing about the wire it drives, so checking
+# the arm signal alone -- all the push path needs, since it only ever deletes the
+# one mux it consumed -- lets the hoist delete a cell the caller asked to keep.
+# What is left above the kept link is two muxes deep and not worth taking alone.
+setattr -set keep 1 t:$pmux
+equiv_opt -assert muxpush -hoist-late
+design -load postopt
+select -assert-count 1 a:keep
+select -assert-count 0 t:$reduce_and
+design -reset
+
+# The same netlist without the keep does hoist, so the group above is the guard
+# declining a real candidate rather than a shape the walk never matched.
+design -load chain_over_pmux
+equiv_opt -assert muxpush -hoist-late
+design -load postopt
+select -assert-count 1 t:$reduce_and
+
+design -reset
+log -pop
+
+
+log -header "-hoist-late: the walk stays inside the selection"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire s0,
+  input wire s1,
+  input wire [1:0] sel,
+  input wire [7:0] e0,
+  input wire [7:0] e1,
+  input wire [7:0] e2,
+  input wire [7:0] e3,
+  input wire [7:0] d_lo,
+  input wire [7:0] d_hi,
+  output wire [7:0] y
+);
+  wire [7:0] late = d_lo * d_hi;
+  reg [7:0] inner;
+  always @* begin
+    (* parallel_case *)
+    case (1'b1)
+      sel[0]:  inner = e2;
+      sel[1]:  inner = e3;
+      default: inner = late;
+    endcase
+  end
+  assign y = s0 ? e0 : (s1 ? e1 : inner);
+endmodule
+EOF
+proc
+check -assert
+
+# Roots come from the selection but the walk follows drivers, so a targeted run
+# would otherwise absorb and delete a link the caller left out. Selecting only
+# the muxes has to end the chain at the pmux, and the two muxes above it are not
+# worth hoisting on their own.
+muxpush -hoist-late t:$mux
+select -assert-count 0 t:$reduce_and
+select -assert-count 1 t:$pmux
 
 design -reset
 log -pop


### PR DESCRIPTION
## Summary

A datapath feeding the **default arm** of a chain of control muxes pays one level per mux above it, even when every select arrives early. The chain is a priority select, so that arm can instead be taken under the accumulated not-taken condition, landing one mux from the output while the early arms rebuild beside it.

New `-hoist-late` mode on `muxpush`:

- Walks `$mux` and `$pmux` priority chains down their default arms. `$pmux` links matter: they lower back into a priority chain, so their default is charged `log2(S_WIDTH)` rather than one level. Pricing it as one level reads the common `case (1'b1)` shape as break-even and leaves the datapath stuck behind the whole case.
- Gated by a before/after arrival estimate under the pass's existing unit model, with `-hoist-gain` (default 2) as the margin the rewrite must clear.

## Why the threshold

Shallow wins do not survive downstream remapping, so the margin is doing real work. Measured across the 117 QoR regression designs:

| `-hoist-gain` | better | worse | net LoL |
|---|---|---|---|
| 1 | 5 | 14 | — |
| **2 (default)** | **5** | **3** | **-5.25** |
| 3 | 1 | 0 | -1.00 |

At the shipped default the wins are `qor_levelsize_pow2_leadone` -2.75, `qor_spi_ra_add_chain_2_full` -2.00, `qor_mod7_digit_sum_3` -1.25, `qor_spi_ra_add_chain_full` -1.00, `qor_levelsize_pow2_leadone_2` -0.50. The regressions are `qor_addr_vps_barrel` +1.50 (area -34.8), `qor_spi_ra_binary_tree_full` +0.75, and `qor_pow2_width_clamp` at +0.9 area only.

## Test plan

- [x] Four new groups in `tests/silimate/mux_push.ys`: the positive case, a chain whose default is not the late arm, the `$pmux` form, and `-hoist-gain` declining a chain the default threshold takes. Each asserts equivalence via `equiv_opt -assert` and keys on the `$reduce_and` guard as the rewrite's signature.
- [x] `equiv_simple` / `equiv_induct` proof on a real design that exercises 107 chains at once.
- [x] Full Preqorsor QoR regression: 117/117 pass.

Made with [Cursor](https://cursor.com)